### PR TITLE
Allow vendor dir in golang's function folder

### DIFF
--- a/template/go-armhf/Dockerfile
+++ b/template/go-armhf/Dockerfile
@@ -1,6 +1,6 @@
 FROM alexellis2/go-armhf:1.8.4
 
-RUN apk --no-cache add curl \ 
+RUN apk --no-cache add curl \
     && echo "Pulling watchdog binary from Github." \
     && curl -sSL https://github.com/openfaas/faas/releases/download/0.6.9/fwatchdog-armhf > /usr/bin/fwatchdog \
     && chmod +x /usr/bin/fwatchdog \
@@ -10,7 +10,7 @@ WORKDIR /go/src/handler
 COPY . .
 
 # Run a gofmt and exclude all vendored code.
-RUN test -z "$(gofmt -l $(find . -type f -name '*.go' -not -path "./vendor/*"))" || { echo "Run \"gofmt -s -w\" on your Golang code"; exit 1; }
+RUN test -z "$(gofmt -l $(find . -type f -name '*.go' -not -path "./vendor/*" -not -path "./function/vendor/*"))" || { echo "Run \"gofmt -s -w\" on your Golang code"; exit 1; }
 
 RUN CGO_ENABLED=0 GOOS=linux \
     go build --ldflags "-s -w" -a -installsuffix cgo -o handler . && \

--- a/template/go/Dockerfile
+++ b/template/go/Dockerfile
@@ -1,6 +1,6 @@
 FROM golang:1.8.3-alpine3.6
 
-RUN apk --no-cache add curl \ 
+RUN apk --no-cache add curl \
     && echo "Pulling watchdog binary from Github." \
     && curl -sSL https://github.com/openfaas/faas/releases/download/0.6.9/fwatchdog > /usr/bin/fwatchdog \
     && chmod +x /usr/bin/fwatchdog \
@@ -10,7 +10,7 @@ WORKDIR /go/src/handler
 COPY . .
 
 # Run a gofmt and exclude all vendored code.
-RUN test -z "$(gofmt -l $(find . -type f -name '*.go' -not -path "./vendor/*"))" || { echo "Run \"gofmt -s -w\" on your Golang code"; exit 1; }
+RUN test -z "$(gofmt -l $(find . -type f -name '*.go' -not -path "./vendor/*" -not -path "./function/vendor/*"))" || { echo "Run \"gofmt -s -w\" on your Golang code"; exit 1; }
 
 RUN CGO_ENABLED=0 GOOS=linux \
     go build --ldflags "-s -w" -a -installsuffix cgo -o handler . && \


### PR DESCRIPTION
The go templates check for formatting, but exclude vendored files in the template folder itself ignoring any additional vendor folder in the function folder.
---
- Add extra eclusion for function/vendor folder when checking file formatting

Fixes OpenFaas/templates#1