### PR TITLE
Fix CSharp build-time warning

### DIFF
--- a/template/csharp/root.csproj
+++ b/template/csharp/root.csproj
@@ -3,7 +3,13 @@
   <ItemGroup>
     <ProjectReference Include="function\Function.csproj" />
   </ItemGroup>
+ <PropertyGroup>
+    <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
+ </PropertyGroup>
 
+<ItemGroup>
+  <Compile Include="./Program.cs"></Compile>
+</ItemGroup>
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp2.0</TargetFramework>


### PR DESCRIPTION
Signed-off-by: Alex Ellis <alexellis2@gmail.com>

Fixes https://github.com/openfaas/faas-cli/pull/306

.NET Core globs - so it already includes the class Library as part of the .exe rather than compiling a separate module/library as desired. This change removes the recursive glob from the root project so the references work correctly without duplicate types. 