### PR TITLE
Add scala-ammonite as a template

### DIFF
--- a/template/scala-ammonite/Dockerfile
+++ b/template/scala-ammonite/Dockerfile
@@ -1,0 +1,24 @@
+FROM openjdk:8-jre-slim
+
+# Install ammonite for scala 2.11 and fwatchdog
+
+RUN apt-get update -qy \
+    && apt-get install -qy curl ca-certificates --no-install-recommends \ 
+    && curl -L -o /bin/amm https://git.io/vdNvV && chmod +x /bin/amm \
+    && echo "Pulling watchdog binary from Github." \
+    && curl -sSL https://github.com/openfaas/faas/releases/download/0.6.9/fwatchdog > /usr/bin/fwatchdog \
+    && chmod +x /usr/bin/fwatchdog \
+    && apt-get -qy remove curl \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+# COPY predef.sc /root/.ammonite/predef.sc
+COPY Main.sc /root/Main.sc
+COPY function/Function.sc /root/function/Function.sc
+
+WORKDIR /root/
+
+ENV fprocess="amm -s /root/Main.sc"
+EXPOSE 8080
+CMD ["fwatchdog"]
+

--- a/template/scala-ammonite/Main.sc
+++ b/template/scala-ammonite/Main.sc
@@ -1,0 +1,7 @@
+//Main.sc
+import $file.function.Function
+
+@main
+def read(): Unit = {
+        for (ln <- io.Source.stdin.getLines) Function.handle(ln)
+}

--- a/template/scala-ammonite/function/Function.sc
+++ b/template/scala-ammonite/function/Function.sc
@@ -1,0 +1,1 @@
+def handle(input: String): Unit = println(input)

--- a/template/scala-ammonite/template.yml
+++ b/template/scala-ammonite/template.yml
@@ -1,0 +1,2 @@
+language: scala-ammonite
+fprocess: amm -s Main.sc


### PR DESCRIPTION
[Ammonite](http://ammonite.io/) is an awesome way of writing Scala code with the minimal effort.

With this template, it is even simpler.

- The function has to be written in the `function/Function.sc` file. 
- The example provided echoes the input.
- The base docker image is "only" 271mb

## Test process

- `docker build -t scala-ammonite scala-ammonite `
- `docker run -p 8080:8080  scala-ammonite`
- `curl -X POST http://localhost:8080 -d 'Hello World'`
- Expected output should be `Hello World`
 