### PR TITLE
set builder alias for build stage

### DIFF
--- a/template/go-armhf/Dockerfile
+++ b/template/go-armhf/Dockerfile
@@ -1,4 +1,4 @@
-FROM alexellis2/go-armhf:1.8.4
+FROM alexellis2/go-armhf:1.8.4 as builder
 
 RUN apk --no-cache add curl \
     && echo "Pulling watchdog binary from Github." \
@@ -26,8 +26,8 @@ RUN chown app /home/app
 
 WORKDIR /home/app
 
-COPY --from=0 /go/src/handler/handler    .
-COPY --from=0 /usr/bin/fwatchdog         .
+COPY --from=builder /go/src/handler/handler    .
+COPY --from=builder /usr/bin/fwatchdog         .
 
 USER app
 

--- a/template/go/Dockerfile
+++ b/template/go/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.8.3-alpine3.6
+FROM golang:1.8.3-alpine3.6 as builder
 
 RUN apk --no-cache add curl \
     && echo "Pulling watchdog binary from Github." \
@@ -26,8 +26,8 @@ RUN chown app /home/app
 
 WORKDIR /home/app
 
-COPY --from=0 /go/src/handler/handler    .
-COPY --from=0 /usr/bin/fwatchdog         .
+COPY --from=builder /go/src/handler/handler    .
+COPY --from=builder /usr/bin/fwatchdog         .
 
 USER app
 


### PR DESCRIPTION
### What is it doing?
This is to give the build stage an alias so that COPY instructions are clearer: `--from=builder` instead of `--from=0`

### Why do we need it?
Giving the build stage an alias makes reading the Dockerfile more comprehensible

### How was it tested?
Only tested with `go` template, armhf is not tested
```
faas-cli new test-go-builder-stage --lang=go
faas-cli build -f test-go-builder-stage.yml
faas-cli deploy -f test-go-builder-stage.yml
echo "test" | faas-cli invoke test-go-builder-stage
```