### PR TITLE
Add node template for typescript

### DIFF
--- a/template/node-typescript/.dockerignore
+++ b/template/node-typescript/.dockerignore
@@ -1,0 +1,3 @@
+*/node_modules
+function/*.js
+function/*.js.map

--- a/template/node-typescript/Dockerfile
+++ b/template/node-typescript/Dockerfile
@@ -1,0 +1,55 @@
+FROM node:8.9.1-alpine
+
+RUN addgroup -S app && adduser -S -g app app
+
+# Alternatively use ADD https:// (which will not be cached by Docker builder)
+RUN apk --no-cache add curl \
+    && echo "Pulling watchdog binary from Github." \
+    && curl -sSL https://github.com/openfaas/faas/releases/download/0.7.6/fwatchdog > /usr/bin/fwatchdog \
+    && chmod +x /usr/bin/fwatchdog \
+    && apk del curl --no-cache
+
+WORKDIR /root/
+
+# Turn down the verbosity to default level.
+ENV NPM_CONFIG_LOGLEVEL warn
+
+RUN mkdir -p /home/app
+
+# Wrapper/boot-strapper
+WORKDIR /home/app
+COPY package.json ./
+
+# This ordering means the npm installation is cached for the outer function handler.
+RUN npm i
+
+# Copy outer function handler
+COPY index.js ./
+
+# COPY function node packages and install, adding this as a separate
+# entry allows caching of npm install
+WORKDIR /home/app/function
+COPY function/*.json ./
+RUN npm i || :
+
+# COPY function files and folders
+COPY function/ ./
+
+# Set correct permissions to use non root user
+WORKDIR /home/app/
+
+# chmod for tmp is for a buildkit issue (@alexellis)
+RUN chown app:app -R /home/app \
+    && chmod 777 /tmp
+
+USER app
+
+RUN ./node_modules/typescript/bin/tsc --project ./function
+
+ENV cgi_headers="true"
+ENV fprocess="node index.js"
+
+HEALTHCHECK --interval=1s CMD [ -e /tmp/.lock ] || exit 1
+
+CMD ["fwatchdog"]
+

--- a/template/node-typescript/function/global.d.ts
+++ b/template/node-typescript/function/global.d.ts
@@ -1,0 +1,3 @@
+type FaaSHandlerCallback = (error: any, result: any) => void;
+type FaasHandlerContext = string | null;
+type FaasHandler = (context: string | null, callback: FaaSHandlerCallback ) => void;

--- a/template/node-typescript/function/handler.ts
+++ b/template/node-typescript/function/handler.ts
@@ -1,0 +1,5 @@
+function handle(context: FaasHandlerContext, callback: FaaSHandlerCallback) {
+    return callback(undefined, {status: "done"});
+}
+
+export = handle

--- a/template/node-typescript/function/package.json
+++ b/template/node-typescript/function/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "function",
+  "version": "1.0.0",
+  "description": "",
+  "main": "handler.ts",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+  },
+  "devDependencies": {}
+}

--- a/template/node-typescript/function/tsconfig.json
+++ b/template/node-typescript/function/tsconfig.json
@@ -1,0 +1,62 @@
+{
+  "compilerOptions": {
+    /* Basic Options */
+    "target": "ES2016",                          /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017','ES2018' or 'ESNEXT'. */
+    "module": "commonjs",                     /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */
+    // "lib": [],                             /* Specify library files to be included in the compilation. */
+    // "allowJs": true,                       /* Allow javascript files to be compiled. */
+    // "checkJs": true,                       /* Report errors in .js files. */
+    // "jsx": "preserve",                     /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */
+    // "declaration": true,                   /* Generates corresponding '.d.ts' file. */
+    "sourceMap": false,                     /* Generates corresponding '.map' file. */
+    // "outFile": "./",                       /* Concatenate and emit output to single file. */
+    // "outDir": "./",                        /* Redirect output structure to the directory. */
+    // "rootDir": "./",                       /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */
+    "removeComments": true,                   /* Do not emit comments to output. */
+    // "noEmit": true,                        /* Do not emit outputs. */
+    // "importHelpers": true,                 /* Import emit helpers from 'tslib'. */
+    // "downlevelIteration": true,            /* Provide full support for iterables in 'for-of', spread, and destructuring when targeting 'ES5' or 'ES3'. */
+    // "isolatedModules": true,               /* Transpile each file as a separate module (similar to 'ts.transpileModule'). */
+
+    /* Strict Type-Checking Options */
+    "strict": true,                           /* Enable all strict type-checking options. */
+    "noImplicitAny": false,                 /* Raise error on expressions and declarations with an implied 'any' type. */
+    // "strictNullChecks": true,              /* Enable strict null checks. */
+    // "strictFunctionTypes": true,           /* Enable strict checking of function types. */
+    // "strictPropertyInitialization": true,  /* Enable strict checking of property initialization in classes. */
+    "noImplicitThis": false,                /* Raise error on 'this' expressions with an implied 'any' type. */
+    // "alwaysStrict": true,                  /* Parse in strict mode and emit "use strict" for each source file. */
+
+    /* Additional Checks */
+    "noUnusedLocals": false,                /* Report errors on unused locals. */
+    "noUnusedParameters": false,            /* Report errors on unused parameters. */
+    "noImplicitReturns": false,             /* Report error when not all code paths in function return a value. */
+    // "noFallthroughCasesInSwitch": true,    /* Report errors for fallthrough cases in switch statement. */
+
+    /* Module Resolution Options */
+    "moduleResolution": "node",            /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */
+    // "baseUrl": "./",                       /* Base directory to resolve non-absolute module names. */
+    // "paths": {},                           /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
+    // "rootDirs": [],                        /* List of root folders whose combined content represents the structure of the project at runtime. */
+     "typeRoots": ["./node_modules/@types/node"],                       /* List of folders to include type definitions from. */
+    "types": [
+         "node"
+    ],                                        /* Type declaration files to be included in compilation. */
+    // "allowSyntheticDefaultImports": true,  /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
+    "esModuleInterop": true                   /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
+    // "preserveSymlinks": true,              /* Do not resolve the real path of symlinks. */
+
+    /* Source Map Options */
+    // "sourceRoot": "./",                    /* Specify the location where debugger should locate TypeScript files instead of source locations. */
+    // "mapRoot": "./",                       /* Specify the location where debugger should locate map files instead of generated locations. */
+    // "inlineSourceMap": true,               /* Emit a single file with source maps instead of having a separate file. */
+    // "inlineSources": true,                 /* Emit the source alongside the sourcemaps within a single file; requires '--inlineSourceMap' or '--sourceMap' to be set. */
+
+    /* Experimental Options */
+    // "experimentalDecorators": true,        /* Enables experimental support for ES7 decorators. */
+    // "emitDecoratorMetadata": true,         /* Enables experimental support for emitting type metadata for decorators. */
+  },
+  "exclude": [
+    "node_modules"
+  ]
+}

--- a/template/node-typescript/index.js
+++ b/template/node-typescript/index.js
@@ -1,0 +1,31 @@
+// Copyright (c) Alex Ellis 2017. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+"use strict"
+
+const getStdin = require('get-stdin');
+
+const handler = require('./function/handler');
+
+getStdin().then(val => {
+    handler(val, (err, res) => {
+        if (err) {
+            return console.error(err);
+        }
+        if(isArray(res) || isObject(res)) {
+            console.log(JSON.stringify(res));
+        } else {
+            process.stdout.write(res);
+        }
+    });
+}).catch(e => {
+    console.error(e.stack);
+});
+
+const isArray = (a) => {
+    return (!!a) && (a.constructor === Array);
+};
+
+const isObject = (a) => {
+    return (!!a) && (a.constructor === Object);
+};

--- a/template/node-typescript/package.json
+++ b/template/node-typescript/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "NodejsBase",
+  "version": "1.0.0",
+  "description": "",
+  "main": "faas_index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "@types/node": "^9.6.1",
+    "get-stdin": "^5.0.1",
+    "typescript": "^2.8.1"
+  }
+}

--- a/template/node-typescript/template.yml
+++ b/template/node-typescript/template.yml
@@ -1,0 +1,2 @@
+language: node
+fprocess: node index.js


### PR DESCRIPTION
## Description
Based in the node template, but with typescript function file. The function compiles to javascript during the docker build process.

## Motivation and Context
We are using Typescript in most of our projects. Recently, we discovered the great project OpenFaaS and we are already using it. Therefore I created a template to write functions in Typescript and I would be very happy if you make it available to other developers by accepting this pull request.

## How Has This Been Tested?
I've created a function using the template and deployed it.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
