### PR TITLE
Move C# template to non-root user

### DIFF
--- a/template/csharp/Dockerfile
+++ b/template/csharp/Dockerfile
@@ -1,14 +1,15 @@
 FROM microsoft/dotnet:2.0-sdk as builder
 
+# Supress collection of data.
 ENV DOTNET_CLI_TELEMETRY_OPTOUT 1
 
 # Optimize for Docker builder caching by adding projects first.
 
-RUN mkdir -p /root/src/function
-WORKDIR /root/src/function
+RUN mkdir -p /home/app/src/function
+WORKDIR /home/app/src/function
 COPY ./function/Function.csproj  .
 
-WORKDIR /root/src/
+WORKDIR /home/app/src/
 COPY ./root.csproj  .
 RUN dotnet restore ./root.csproj
 
@@ -18,8 +19,12 @@ RUN dotnet publish -c release -o published
 
 FROM microsoft/dotnet:2.0-runtime
 
-RUN apt-get update -qy \
-    && apt-get install -qy curl ca-certificates --no-install-recommends \ 
+# Create a non-root user
+RUN addgroup --system app \
+    && adduser --system --ingroup app app \
+    && apt-get update -qy \
+    && apt-get install -qy \
+       curl ca-certificates --no-install-recommends \ 
     && echo "Pulling watchdog binary from Github." \
     && curl -sSL https://github.com/openfaas/faas/releases/download/0.7.9/fwatchdog > /usr/bin/fwatchdog \
     && chmod +x /usr/bin/fwatchdog \
@@ -27,10 +32,16 @@ RUN apt-get update -qy \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-WORKDIR /root/
-COPY --from=builder /root/src/published .
+WORKDIR /home/app/
+COPY --from=builder /home/app/src/published .
+
+RUN chown app:app -R /home/app
+
+USER app
 
 ENV fprocess="dotnet ./root.dll"
 EXPOSE 8080
-CMD ["fwatchdog"]
 
+HEALTHCHECK --interval=1s CMD [ -e /tmp/.lock ] || exit 1
+
+CMD ["fwatchdog"]


### PR DESCRIPTION
This commit picks up unfinished community PRs from faas-cli repo
with some input from @iyovcheva.

Testing has been done with a nuget package (Newtonsoft.Json) on
Docker for Mac with Kubernetes and faas-netesd:0.5.0

https://www.newtonsoft.com/json/help/html/T_Newtonsoft_Json_JsonConvert.htm

Also adds (missing) healthcheck for Swarm

Closes #24

Signed-off-by: Alex Ellis (VMware) <alexellis2@gmail.com>

Add package:

```
dotnet add package Newtonsoft.Json
```

Function code:

```
using System;
using System.Text;
using Newtonsoft.Json;

namespace Function
{
    public class Movie {
        public string Name {get;set;}
    }

    public class FunctionHandler
    {
        public void Handle(string input) {

            string json = @"{
'Name': 'Bad Boys',
'ReleaseDate': '1995-4-7T00:00:00',
'Genres': [
    'Action',
    'Comedy'
]
}";

            Movie m = JsonConvert.DeserializeObject<Movie>(json);

            string name = m.Name;

            Console.WriteLine("Hi there - movie name was: "+ name);
        }
    }
}

```