### PR TITLE
Edit python templates to support `build_options` feature

### DIFF
--- a/template/python-armhf/Dockerfile
+++ b/template/python-armhf/Dockerfile
@@ -1,6 +1,8 @@
 FROM armhf/python:2.7-alpine
+
+ARG ADDITIONAL_PACKAGE
 # Alternatively use ADD https:// (which will not be cached by Docker builder)
-RUN apk --no-cache add curl \ 
+RUN apk --no-cache add curl ${ADDITIONAL_PACKAGE} \ 
     && echo "Pulling watchdog binary from Github." \
     && curl -sSL https://github.com/openfaas/faas/releases/download/0.8.0/fwatchdog-armhf > /usr/bin/fwatchdog \
     && chmod +x /usr/bin/fwatchdog \

--- a/template/python-armhf/template.yml
+++ b/template/python-armhf/template.yml
@@ -1,2 +1,13 @@
 language: python-armhf
 fprocess: python index.py
+build_options: 
+  - name: dev
+    packages: 
+      - make
+      - automake
+      - gcc
+      - g++
+      - subversion
+      - python3-dev
+      - musl-dev
+      - libffi-dev

--- a/template/python/Dockerfile
+++ b/template/python/Dockerfile
@@ -1,7 +1,8 @@
 FROM python:2.7-alpine
 
+ARG ADDITIONAL_PACKAGE
 # Alternatively use ADD https:// (which will not be cached by Docker builder)
-RUN apk --no-cache add curl \ 
+RUN apk --no-cache add curl ${ADDITIONAL_PACKAGE} \
     && echo "Pulling watchdog binary from Github." \
     && curl -sSL https://github.com/openfaas/faas/releases/download/0.8.0/fwatchdog > /usr/bin/fwatchdog \
     && chmod +x /usr/bin/fwatchdog \

--- a/template/python/template.yml
+++ b/template/python/template.yml
@@ -1,2 +1,13 @@
 language: python
 fprocess: python index.py
+build_options: 
+  - name: dev
+    packages: 
+      - make
+      - automake
+      - gcc
+      - g++
+      - subversion
+      - python3-dev
+      - musl-dev
+      - libffi-dev

--- a/template/python3-armhf/Dockerfile
+++ b/template/python3-armhf/Dockerfile
@@ -1,7 +1,8 @@
 FROM armhf/python:3.6-alpine
 
+ARG ADDITIONAL_PACKAGE
 # Alternatively use ADD https:// (which will not be cached by Docker builder)
-RUN apk --no-cache add curl \ 
+RUN apk --no-cache add curl ${ADDITIONAL_PACKAGE} \ 
     && echo "Pulling watchdog binary from Github." \
     && curl -sSL https://github.com/openfaas/faas/releases/download/0.8.0/fwatchdog-armhf > /usr/bin/fwatchdog \
     && chmod +x /usr/bin/fwatchdog \

--- a/template/python3-armhf/template.yml
+++ b/template/python3-armhf/template.yml
@@ -1,2 +1,13 @@
 language: python3-armhf
 fprocess: python3 index.py
+build_options: 
+  - name: dev
+    packages: 
+      - make
+      - automake
+      - gcc
+      - g++
+      - subversion
+      - python3-dev
+      - musl-dev
+      - libffi-dev

--- a/template/python3/Dockerfile
+++ b/template/python3/Dockerfile
@@ -1,7 +1,10 @@
 FROM python:3-alpine
 
+# Allows you to add additional packages via build-arg
+ARG ADDITIONAL_PACKAGE
+
 # Alternatively use ADD https:// (which will not be cached by Docker builder)
-RUN apk --no-cache add curl \ 
+RUN apk --no-cache add curl ${ADDITIONAL_PACKAGE} \ 
     && echo "Pulling watchdog binary from Github." \
     && curl -sSL https://github.com/openfaas/faas/releases/download/0.8.0/fwatchdog > /usr/bin/fwatchdog \
     && chmod +x /usr/bin/fwatchdog \

--- a/template/python3/template.yml
+++ b/template/python3/template.yml
@@ -1,2 +1,13 @@
 language: python3
 fprocess: python3 index.py
+build_options: 
+  - name: dev
+    packages: 
+      - make
+      - automake
+      - gcc
+      - g++
+      - subversion
+      - python3-dev
+      - musl-dev
+      - libffi-dev


### PR DESCRIPTION
This change allows the python3 template to make use of the new faas-cli feature  - support for building native modules i.e. C/C++.

The packages listed in `template.yml` will be built if a `--build_option=dev` flag is used with `faas-cli` build.

Thanks to @kenfdev for sharing a function to test with.
[faas-pandas-example](https://github.com/kenfdev/faas-pandas-example)

Signed-off-by: Ivana Yovcheva (VMware) <iyovcheva@vmware.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))
[#28](https://github.com/openfaas/templates/issues/28)

## How Has This Been Tested?
Tested together with [faas-cli/#414](https://github.com/openfaas/faas-cli/pull/414)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.