### PR TITLE
Add mysql build option

### DIFF
--- a/template/python/template.yml
+++ b/template/python/template.yml
@@ -12,3 +12,7 @@ build_options:
       - musl-dev
       - libffi-dev
       - git
+  - name: mysql
+    packages: 
+      - mysql-client
+      - mysql-dev

--- a/template/python3/template.yml
+++ b/template/python3/template.yml
@@ -12,3 +12,7 @@ build_options:
       - musl-dev
       - libffi-dev
       - git
+  - name: mysql
+    packages: 
+      - mysql-client
+      - mysql-dev


### PR DESCRIPTION
With this change `python` and `python3` templates are updated to
support building mysql packages

Signed-off-by: Ivana Yovcheva (VMware) <iyovcheva@vmware.com>

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

Discussed with @alexellis on slack

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

`requirements.txt`:
```
mysqlclient
mysql-connector-python-rf
```
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.