### PR TITLE
Fix user group for dockerfile

### DIFF
--- a/template/dockerfile/function/Dockerfile
+++ b/template/dockerfile/function/Dockerfile
@@ -18,7 +18,7 @@ RUN apk --no-cache add curl \
     
 # Add non root user
 
-RUN addgroup -S app && adduser -S -g app app
+RUN addgroup -S app && adduser app -S -G app
 
 RUN chown app /home/app
 


### PR DESCRIPTION
This fixes dockerfile template to set app group properly.
Before used to add GEO data for user, after the change adds group to user

Signed-off-by: Ivana Yovcheva (VMware) <iyovcheva@vmware.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

## Which issue(s) this PR fixes 
<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged): -->
Fixes #41

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Manually tested with `docker run -ti <image> sh` and by building function template.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.