### PR TITLE
Update node-armhf template to use non-root user

### DIFF
--- a/template/node-armhf/Dockerfile
+++ b/template/node-armhf/Dockerfile
@@ -1,5 +1,7 @@
 FROM arm32v6/alpine:3.6
 
+RUN addgroup -S app && adduser app -S -G app
+
 RUN apk add --no-cache nodejs nodejs-npm ca-certificates
 RUN apk --no-cache add curl \
     && echo "Pulling watchdog binary from Github." \
@@ -7,18 +9,32 @@ RUN apk --no-cache add curl \
     && chmod +x /usr/bin/fwatchdog \
     && apk del curl --no-cache
 
-WORKDIR /root/
+RUN mkdir -p /home/app
+
+# Wrapper/boot-strapper
+WORKDIR /home/app
 
 COPY package.json   .
 
 RUN npm i
+
+WORKDIR /home/app/function
+
 COPY index.js       .
 COPY function       function
-WORKDIR /root/function
 
 ENV NPM_CONFIG_LOGLEVEL warn
 RUN npm i || :
-WORKDIR /root/
+
+COPY --chown=app:app function/ .
+
+WORKDIR /home/app/
+
+RUN chmod +rx -R ./function \
+    && chown app:app -R /home/app \
+    && chmod 777 /tmp
+
+USER app
 
 ENV cgi_headers="true"
 


### PR DESCRIPTION
This updates the node-armhf function template to use a non-root
user. Creates `app` system user  and `app` group

Signed-off-by: Ivana Yovcheva (VMware) <iyovcheva@vmware.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

## Which issue(s) this PR fixes 
<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged): -->
Fixes #23 #41

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Local build of simple node-armhf function

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.