### PR TITLE
Run ruby as non-root

### DIFF
--- a/template/ruby/Dockerfile
+++ b/template/ruby/Dockerfile
@@ -27,6 +27,8 @@ RUN addgroup -S app \
 
 RUN chown app:app -R /home/app
 
+USER app
+
 WORKDIR /home/app
 
 ENV fprocess="ruby index.rb"


### PR DESCRIPTION
Ruby template is creating non-root user, but still used to run as
a root. This change updates to run as app instead

Signed-off-by: Ivana Yovcheva (VMware) <iyovcheva@vmware.com>

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

## Which issue(s) this PR fixes 
<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged): -->
Fixes #68 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

1. `faas-cli new --lang ruby ruby-test`
2. `faas-cli up`
3. 
```
$ docker run -ti ruby-test:latest sh
# whoami
app
```
4. 
```
$ faas-cli invoke
Hello world from the Ruby template
```
5.
`Gemfile`:
```
gem 'nokogiri'
```

`handler.rb`:
```
require 'nokogiri'

class Handler
    def run(req)
        html_doc = Nokogiri::HTML("<html><body><h1>Some message here</h1></body></html>")
        return html_doc
    end
end
```

```
$ faas-cli up --build-option dev
$ faas-cli invoke

<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN" "http://www.w3.org/TR/REC-html40/loose.dtd">
<html><body><h1>Some message here</h1></body></html>

```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.