### PR TITLE
Add "EXPOSE 8080" to all templates

### DIFF
--- a/template/dockerfile/function/Dockerfile
+++ b/template/dockerfile/function/Dockerfile
@@ -31,5 +31,7 @@ ENV fprocess="cat"
 # Set to true to see request in function logs
 ENV write_debug="false"
 
+EXPOSE 8080
+
 HEALTHCHECK --interval=5s CMD [ -e /tmp/.lock ] || exit 1
 CMD [ "fwatchdog" ]

--- a/template/go-armhf/Dockerfile
+++ b/template/go-armhf/Dockerfile
@@ -32,5 +32,6 @@ COPY --from=builder /usr/bin/fwatchdog         .
 USER app
 
 ENV fprocess="./handler"
+EXPOSE 8080
 
 CMD ["./fwatchdog"]

--- a/template/go/Dockerfile
+++ b/template/go/Dockerfile
@@ -35,6 +35,7 @@ RUN chown -R app /home/app
 USER app
 
 ENV fprocess="./handler"
+EXPOSE 8080
 
 HEALTHCHECK --interval=2s CMD [ -e /tmp/.lock ] || exit 1
 

--- a/template/java8/Dockerfile
+++ b/template/java8/Dockerfile
@@ -42,6 +42,7 @@ ENV mode="http"
 ENV CLASSPATH="/home/app/entrypoint-1.0/lib/*"
 
 ENV fprocess="java com.openfaas.entrypoint.App"
+EXPOSE 8080
 
 HEALTHCHECK --interval=2s CMD [ -e /tmp/.lock ] || exit 1
 

--- a/template/node-arm64/Dockerfile
+++ b/template/node-arm64/Dockerfile
@@ -34,6 +34,7 @@ WORKDIR /root/
 ENV cgi_headers="true"
 
 ENV fprocess="node index.js"
+EXPOSE 8080
 
 HEALTHCHECK --interval=1s CMD [ -e /tmp/.lock ] || exit 1
 

--- a/template/node-armhf/Dockerfile
+++ b/template/node-armhf/Dockerfile
@@ -23,6 +23,7 @@ WORKDIR /root/
 ENV cgi_headers="true"
 
 ENV fprocess="node index.js"
+EXPOSE 8080
 
 HEALTHCHECK --interval=1s CMD [ -e /tmp/.lock ] || exit 1
 

--- a/template/node/Dockerfile
+++ b/template/node/Dockerfile
@@ -46,6 +46,7 @@ USER app
 
 ENV cgi_headers="true"
 ENV fprocess="node index.js"
+EXPOSE 8080
 
 HEALTHCHECK --interval=1s CMD [ -e /tmp/.lock ] || exit 1
 

--- a/template/python-armhf/Dockerfile
+++ b/template/python-armhf/Dockerfile
@@ -33,6 +33,7 @@ COPY function           function
 
 
 ENV fprocess="python index.py"
+EXPOSE 8080
 
 HEALTHCHECK --interval=1s CMD [ -e /tmp/.lock ] || exit 1
 

--- a/template/python/Dockerfile
+++ b/template/python/Dockerfile
@@ -36,6 +36,7 @@ RUN chown -R app:app ./
 USER app
 
 ENV fprocess="python index.py"
+EXPOSE 8080
 
 HEALTHCHECK --interval=1s CMD [ -e /tmp/.lock ] || exit 1
 

--- a/template/python3-armhf/Dockerfile
+++ b/template/python3-armhf/Dockerfile
@@ -32,6 +32,7 @@ WORKDIR /home/app/
 COPY function           function
 
 ENV fprocess="python3 index.py"
+EXPOSE 8080
 
 HEALTHCHECK --interval=1s CMD [ -e /tmp/.lock ] || exit 1
 

--- a/template/python3/Dockerfile
+++ b/template/python3/Dockerfile
@@ -39,6 +39,7 @@ RUN chown -R app:app ./
 USER app
 
 ENV fprocess="python3 index.py"
+EXPOSE 8080
 
 HEALTHCHECK --interval=1s CMD [ -e /tmp/.lock ] || exit 1
 

--- a/template/ruby/Dockerfile
+++ b/template/ruby/Dockerfile
@@ -32,6 +32,7 @@ USER app
 WORKDIR /home/app
 
 ENV fprocess="ruby index.rb"
+EXPOSE 8080
 
 HEALTHCHECK --interval=2s CMD [ -e /tmp/.lock ] || exit 1
 


### PR DESCRIPTION
By adding `EXPOSE 8080` to all templates we make them usable with
`docker run -P` which can bind a random local port for
testing / debug

Signed-off-by: Ivana Yovcheva (VMware) <iyovcheva@vmware.com>



## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

Resolves #74 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] (kind of) New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
