### PR TITLE
Ruby Dockerfile whitespace cleanup

### DIFF
--- a/template/ruby/Dockerfile
+++ b/template/ruby/Dockerfile
@@ -11,16 +11,16 @@ RUN apk --no-cache add curl ${ADDITIONAL_PACKAGE} \
 
 WORKDIR /home/app
 
-COPY Gemfile    		.
-COPY index.rb           .
-COPY function           function
+COPY Gemfile   .
+COPY index.rb  .
+COPY function  function
 
 RUN bundle install \
   && mkdir -p /home/app/function
 
 WORKDIR /home/app/function
 
-RUN bundle install 
+RUN bundle install
 
 RUN addgroup -S app \
   && adduser app -S -G app


### PR DESCRIPTION
I noticed some inconsistencies in the whitespace ruby Dockerfile which lead to *ugly* output when building functions:

```
Step 5/18 : COPY Gemfile                .
 ...
Step 6/18 : COPY index.rb           .
 ...
Step 7/18 : COPY function           function
...
```

## Description
Indentation changes
