### PR TITLE
update Ruby code according to usual ruby styles

### DIFF
--- a/template/ruby/function/handler.rb
+++ b/template/ruby/function/handler.rb
@@ -1,5 +1,5 @@
 class Handler
-    def run(req)
-        return "Hello world from the Ruby template"
-    end
+  def run(req)
+    return "Hello world from the Ruby template"
+  end
 end

--- a/template/ruby/template.yml
+++ b/template/ruby/template.yml
@@ -1,8 +1,8 @@
 language: ruby
 fprocess: ruby index.rb
-build_options: 
+build_options:
   - name: dev
-    packages: 
+    packages:
       - make
       - automake
       - gcc


### PR DESCRIPTION
Formats code according to usual ruby styling

## Description
In Ruby, code is usually indented with 2 spaces instead of 4

https://github.com/rubocop-hq/ruby-style-guide#source-code-layout

### Why is this necessary?
It's not, but whenever I create a new function I find myself auto-indenting this file :smile: