### PR TITLE
Add getPath to Java8 template

### DIFF
--- a/template/java8/entrypoint/src/main/java/com/openfaas/entrypoint/App.java
+++ b/template/java8/entrypoint/src/main/java/com/openfaas/entrypoint/App.java
@@ -72,7 +72,7 @@ public class App {
             //     System.out.println("Req header " + entry.getKey() + " " + entry.getValue());
             // }
 
-            IRequest req = new Request(requestBody, reqHeadersMap,t.getRequestURI().getRawQuery());
+            IRequest req = new Request(requestBody, reqHeadersMap,t.getRequestURI().getRawQuery(), t.getRequestURI().getPath());
             
             IResponse res = this.handler.Handle(req);
 

--- a/template/java8/model/src/main/java/com/openfaas/model/IRequest.java
+++ b/template/java8/model/src/main/java/com/openfaas/model/IRequest.java
@@ -11,5 +11,6 @@ public interface IRequest {
     String getHeader(String key);
     String getQueryRaw();
     Map<String, String> getQuery();
+    String getPathRaw();
+    Map<String, String> getPath();
 }
-

--- a/template/java8/model/src/main/java/com/openfaas/model/Request.java
+++ b/template/java8/model/src/main/java/com/openfaas/model/Request.java
@@ -8,23 +8,28 @@ import java.util.HashMap;
 import java.net.URLDecoder;
 import java.io.UnsupportedEncodingException;
 
+
 public class Request implements IRequest {
 
     private Map<String, String> headers;
     private String body;
     private Map<String, String> queryParameters;
     private String queryRaw;
+    private String pathRaw;
+    private Map<String, String> path;
 
     public Request(String body, Map<String, String> headers) {
         this.body = body;
         this.headers = headers;
     }
     
-    public Request(String body, Map<String, String> headers,String queryRaw) {
+    public Request(String body, Map<String, String> headers,String queryRaw, String path) {
         this.body = body;
         this.headers = headers;
         this.queryRaw = queryRaw;
         this.queryParameters = this.parseQueryParameters();
+        this.pathRaw = path;
+        this.path = this.parsePathParameters();
     }
 
     public String getBody() {
@@ -51,6 +56,39 @@ public class Request implements IRequest {
     @Override
 	public Map<String, String> getQuery() {
     	return queryParameters;
+    }
+
+    @Override
+    public String getPathRaw() {
+        return pathRaw;
+    }
+
+    @Override
+    public Map<String, String> getPath() {
+        return path;
+    }
+
+    private Map<String, String> parsePathParameters() {
+        Map<String, String> res = new HashMap<String, String>();
+        if (pathRaw != null && pathRaw.length() > 0) {
+            String firstLetter = pathRaw.substring(0,1);
+            String[] params = pathRaw.substring(1).split("/");
+
+            String key = "";
+            for (String param : params) {
+                if (key.length() > 0) {
+                    res.put(key, param);
+                    key = "";
+                } else {
+                    key = param;
+                }
+            }
+            if (key.length() > 0 ) {
+                res.put(key, "");
+            }
+        }
+
+        return res;
     }
     
 	private Map<String, String> parseQueryParameters() {

--- a/template/java8/model/src/test/java/RequestTest.java
+++ b/template/java8/model/src/test/java/RequestTest.java
@@ -10,14 +10,14 @@ public class RequestTest {
 	@Test
 	public void testSingleRequestParameterGetSet()
 	{
-		Request request = new Request(null,null,"testParam=testParamValue");
+		Request request = new Request(null,null,"testParam=testParamValue", null);
 		assertEquals("testParamValue", request.getQuery().get("testParam"));
 	}
 	
 	@Test
 	public void testMultipleRequestParametersGetSet()
 	{
-		Request request = new Request(null,null,"testParam1=testParamValue1&testParam2=testParamValue2");
+		Request request = new Request(null,null,"testParam1=testParamValue1&testParam2=testParamValue2", null);
 		assertEquals("testParamValue1", request.getQuery().get("testParam1"));
 		assertEquals("testParamValue2", request.getQuery().get("testParam2"));
 	}
@@ -25,21 +25,105 @@ public class RequestTest {
 	@Test
 	public void testNullRequestParameterGetSet()
 	{
-		Request request = new Request(null,null,null);
+		Request request = new Request(null,null,null, null);
 		assertEquals(null, request.getQuery().get("testParam"));
 	}
 	
 	@Test
 	public void testEmptyRequestParameterGetSet()
 	{
-		Request request = new Request(null,null,"");
+		Request request = new Request(null,null,"", null);
 		assertEquals(null, request.getQuery().get("testParam"));
 	}
 	
 	@Test
 	public void testRequestRawGetSet()
 	{
-		Request request = new Request(null,null,"testRaw=testRawValue");
+		Request request = new Request(null,null,"testRaw=testRawValue", null);
 		assertEquals("testRaw=testRawValue", request.getQueryRaw());
+	}
+
+	@Test
+	public void testGetPath()
+	{
+		Request request = new Request(null,null, null, "/test/path");
+		try {
+			assertEquals("/test/path", request.getPathRaw());
+		} catch (AssertionError e) {
+			System.out.format("Expected: /test/path Got: %s", request.getPathRaw());
+			throw e;
+		}
+	}
+
+	@Test
+	public void testGetPathWithNullPath()
+	{
+		Request request = new Request(null,null, null, null);
+		try {
+			assertNull(request.getPathRaw());
+		} catch (AssertionError e) {
+			System.out.format("Expected: null Got: %s", request.getPathRaw());
+			throw e;
+		}
+	}
+
+	@Test
+	public void testParseParametersWithoutAnyParameters()
+	{
+		Request request = new Request(null,null, null, "/");
+		try {
+			assertEquals(0, request.getPath().size());
+		} catch (AssertionError e) {
+			System.out.format("Expected: 0 Got: %s", request.getPath().size());
+			throw e;
+		}
+
+		Request emptyRequest = new Request(null,null, null, "");
+		try {
+			assertEquals(0, emptyRequest.getPath().size());
+		} catch (AssertionError e) {
+			System.out.format("Expected: 0 Got: %s", emptyRequest.getPath().size());
+			throw e;
+		}
+	}
+
+	@Test
+	public void testParseParametersWithEvenParameters()
+	{
+		Request request = new Request(null,null, null, "/param1/value1/param2/value2");
+		Map<String, String> params = request.getPath();
+
+		try {
+			assertEquals("value1", params.get("param1"));
+		} catch (AssertionError e) {
+			System.out.format("Expected: value1 Got: %s", params.get("param1"));
+			throw e;
+		}
+		try {
+			assertEquals("value2", params.get("param2"));
+		} catch (AssertionError e) {
+			System.out.format("Expected: value2 Got: %s", params.get("param2"));
+			throw e;
+		}
+	}
+
+	@Test
+	public void testParseParametersWithOddParameters()
+	{
+		Request request = new Request(null,null, null, "/param1/value1/param2");
+		Map<String, String> params = request.getPath();
+
+		try {
+			assertEquals("value1", params.get("param1"));
+		} catch (AssertionError e) {
+			System.out.format("Expected: value1 Got: %s", params.get("param1"));
+			throw e;
+		}
+		try {
+			assertEquals("", params.get("param2"));
+		} catch (AssertionError e) {
+			System.out.format("Expected: value2 Got: %s", params.get("param2"));
+			throw e;
+		}
 	}
 }


### PR DESCRIPTION
Since OpenFaaS now supports path parameters we should update the
template to be able to use path for passing them. Until now this
was supported only by the body or by query

Signed-off-by: Ivana Yovcheva (VMware) <iyovcheva@vmware.com>

<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

## Which issue(s) this PR fixes 
<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged): -->
Fixes #77 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Running the unit test with
```
cd template/java8/model
$ gradle build

BUILD SUCCESSFUL in 2s
14 actionable tasks: 10 executed, 4 up-to-date
```

Tested with function.
Handler.java:
```
package com.openfaas.function;

import com.openfaas.model.IHandler;
import com.openfaas.model.IResponse;
import com.openfaas.model.IRequest;
import com.openfaas.model.Response;

import java.io.*;
import java.net.URISyntaxException;
import java.net.URL;
import java.util.*;
import java.nio.file.Files;
import java.nio.file.Paths;

public class Handler implements com.openfaas.model.IHandler {

    public IResponse Handle(IRequest req) {

        String path = req.getPathRaw();
        Map<String, String> params = req.getPath();

        Response res = new Response();
        res.setBody("Path: " + path + " Params: param1=" + params.get("param1") + " param2="+ params.get("param2"));
	    return res;
    }
}
```

```
$ curl -X GET http://127.0.0.1:8080/function/hello-java-with-path/param1/value1/param2/value2
Path: /param1/value1/param2/value2 Params: param1=value1 param2=value2

$ curl -X GET http://127.0.0.1:8080/function/hello-java-with-path/param1/value1/param2/
Path: /param1/value1/param2/ Params: param1=value1 param2=""
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.