### PR TITLE
Copy private NPM credentials if exists

### DIFF
--- a/template/node/Dockerfile
+++ b/template/node/Dockerfile
@@ -16,7 +16,7 @@ RUN mkdir -p /home/app
 
 # Wrapper/boot-strapper
 WORKDIR /home/app
-COPY package.json ./
+COPY package.json .npmrc ./
 
 # This ordering means the npm installation is cached for the outer function handler.
 RUN npm i --production


### PR DESCRIPTION

## Description

## Motivation and Context

Some projects have dependencies in private NPM registries. Currently, `faas-cli build` will release an incomplete image which dependency errors in production.

This change will copy a `.npmrc` containing the NPM registry auth token, if it is present.

- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

## Which issue(s) this PR fixes 

Fixes #103 
