### PR TITLE
Java8/gradle support for proxy settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,4 @@ build
 .project
 .gradle
 .idea
-#template
+template

--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,4 @@ build
 .project
 .gradle
 .idea
-template
+#template

--- a/template/java8/Dockerfile
+++ b/template/java8/Dockerfile
@@ -15,7 +15,8 @@ ENV PATH=$PATH:$GRADLE_HOME/bin
 
 RUN mkdir -p /home/app/libs
 
-ENV GRADLE_OPTS="-Dorg.gradle.daemon=false"
+ARG gradle_opts
+ENV GRADLE_OPTS=$gradle_opts
 WORKDIR /home/app
 
 COPY . /home/app/

--- a/template/java8/README.md
+++ b/template/java8/README.md
@@ -22,3 +22,9 @@ Tests are supported with junit via files in `./src/test`
 
 External dependencies can be specified in ./build.gradle in the normal way using jcenter, a local JAR or some other remote repository.
 
+### Proxy settings for Gradle
+
+Specify proxy settings using the `gradle_opts` build argument
+```bash
+$ faas-cli up -b gradle_opts="-Dhttp.proxyHost=my-proxy -Dhttp.proxyPort=3128 -Dhttps.proxyHost=my-proxy -Dhttps.proxyPort=3128"
+```

--- a/template/java8/gradle.properties
+++ b/template/java8/gradle.properties
@@ -1,0 +1,1 @@
+org.gradle.daemon=false


### PR DESCRIPTION
Modified Dockerfile for java8 to accept gradle_ops via --build_arg
With this modification now you can pass graddle_ops using --build_arg, so you can specify proxy settings for Gradle.
Signed-off-by: Patricio Diaz <padiazg@gmail.com>


## Description
* Moved `org.gradle.daemon=false` to gradle.propoerties, deleted it from Dockerfile
* Added `ARG` and `ENV` command to Dockerfile to catch GRADLE_OPTS passed as parameter.
* Updated README.md to show how to use it in an corporate proxy scenario

## Motivation and Context
This is needed for successfully building functions if you are behind a proxy
https://github.com/openfaas/templates/issues/105

- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

## Which issue(s) this PR fixes 
Fixes #105 

## How Has This Been Tested?
1) Created new project folder
2) Copied manually modified `template` folder into it.
3) faas-cli.exe new java8-proxy --lang java
4) faas-cli up -f java8-proxy.yml -b gradle_opts="-Dhttp.proxyHost=my-proxy -Dhttp.proxyPort=3128 -Dhttps.proxyHost=my-proxy -Dhttps.proxyPort=3128"

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
