### PR TITLE
Use 8-jdk-alpine instead of a fixed version like 8u121-jdk-alpine

### DIFF
--- a/template/java8/Dockerfile
+++ b/template/java8/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:8u121-jdk-alpine as builder
+FROM openjdk:8-jdk-alpine as builder
 
 RUN apk --no-cache add curl \
     && addgroup -S app && adduser -S -g app app \
@@ -22,7 +22,7 @@ COPY . /home/app/
 
 RUN gradle build
 
-FROM openjdk:8u121-jdk-alpine as ship
+FROM openjdk:8-jdk-alpine as ship
 RUN apk --no-cache add curl \
     && echo "Pulling watchdog binary from Github." \
     && curl -sSL https://github.com/openfaas-incubator/of-watchdog/releases/download/0.4.6/of-watchdog > /usr/bin/fwatchdog \


### PR DESCRIPTION
## Description
Use 8-jdk-alpine instead of a fixed version like 8u121-jdk-alpine

## Motivation and Context
This alleviates the work to update Java to the latest update version. The reason that I did this, is to make use of the new multiarch image for OpenJDK. This means that it won't be necessary to write separate templates for Arm, X64, S390 etc. Just building on the target architecture will create a function that will work on that architecture.
  
## Which issue(s) this PR fixes 

## How Has This Been Tested?
I've created a Java function that runs on my Raspberry Pi cluster. (Won't work out of the box, will work after my change)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [ ] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
