### PR TITLE
Minor improvements (string interpolation in the C# example, removes some blanks)

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ This project is part of the OpenFaaS project licensed under the MIT License.
 | go | Go | 1.10.4 | Alpine Linux 3.8 | Classic | [Go template](https://github.com/openfaas/templates/tree/master/template/go)
 |java8 | Java | 8 | OpenJDK Alpine Linux | of-watchdog | [Java template](https://github.com/openfaas/templates/tree/master/template/java8)
 | node-arm64 | NodeJS | 8.9.1 | N/A | Classic | [NodeJS arm64 template](https://github.com/openfaas/templates/tree/master/template/node-arm64)
-| node-armhf | NodeJS | N/A | Alpine Linux 3.6 | Classic | [NodeJS armhf template](https://github.com/openfaas/templates/tree/master/template/node-armhf) 
+| node-armhf | NodeJS | N/A | Alpine Linux 3.6 | Classic | [NodeJS armhf template](https://github.com/openfaas/templates/tree/master/template/node-armhf)
 | node | NodeJS | 8.9.1 | Alpine Linux | Classic | [NodeJS template](https://github.com/openfaas/templates/tree/master/template/node)
 | php7 | PHP | 7.2 | Alpine Linux | Classic | [PHP 7 template](https://github.com/openfaas/templates/tree/master/template/php7)
 | python-armhf | Python | 2.7 | Alpine Linux | Classic | [Python 2.7 armhf template](https://github.com/openfaas/templates/tree/master/template/python-armhf)

--- a/template/csharp-armhf/function/FunctionHandler.cs
+++ b/template/csharp-armhf/function/FunctionHandler.cs
@@ -6,7 +6,7 @@ namespace Function
     public class FunctionHandler
     {
         public string Handle(string input) {
-            return string.Format("Hi there - your input was: {0}\n", input);
+            return $"Hi there - your input was: {input}\n";
         }
     }
 }

--- a/template/csharp/function/FunctionHandler.cs
+++ b/template/csharp/function/FunctionHandler.cs
@@ -6,7 +6,7 @@ namespace Function
     public class FunctionHandler
     {
         public string Handle(string input) {
-            return string.Format("Hi there - your input was: {0}\n", input);
+            return $"Hi there - your input was: {input}\n";
         }
     }
 }

--- a/template/dockerfile/function/Dockerfile
+++ b/template/dockerfile/function/Dockerfile
@@ -8,7 +8,7 @@ RUN apk --no-cache add curl \
     && chmod +x /usr/bin/fwatchdog \
     && cp /usr/bin/fwatchdog /home/app \
     && apk del curl --no-cache
-    
+
 # Add non root user
 RUN addgroup -S app && adduser app -S -G app
 

--- a/template/node-arm64/Dockerfile
+++ b/template/node-arm64/Dockerfile
@@ -1,7 +1,7 @@
 FROM arm64v8/node:8.9.1
 
 RUN apt-get update -qy \
-    && apt-get install -qy curl ca-certificates --no-install-recommends \ 
+    && apt-get install -qy curl ca-certificates --no-install-recommends \
     && echo "Pulling watchdog binary from Github." \
     && curl -sSL https://github.com/openfaas/faas/releases/download/0.9.14/fwatchdog-arm64 > /usr/bin/fwatchdog \
     && chmod +x /usr/bin/fwatchdog \

--- a/template/python-armhf/Dockerfile
+++ b/template/python-armhf/Dockerfile
@@ -2,7 +2,7 @@ FROM armhf/python:2.7-alpine
 
 ARG ADDITIONAL_PACKAGE
 # Alternatively use ADD https:// (which will not be cached by Docker builder)
-RUN apk --no-cache add curl ${ADDITIONAL_PACKAGE} \ 
+RUN apk --no-cache add curl ${ADDITIONAL_PACKAGE} \
     && echo "Pulling watchdog binary from Github." \
     && curl -sSL https://github.com/openfaas/faas/releases/download/0.9.14/fwatchdog-armhf > /usr/bin/fwatchdog \
     && chmod +x /usr/bin/fwatchdog \

--- a/template/python3-armhf/Dockerfile
+++ b/template/python3-armhf/Dockerfile
@@ -2,7 +2,7 @@ FROM armhf/python:3.6-alpine
 
 ARG ADDITIONAL_PACKAGE
 
-RUN apk --no-cache add curl ${ADDITIONAL_PACKAGE} \ 
+RUN apk --no-cache add curl ${ADDITIONAL_PACKAGE} \
     && echo "Pulling watchdog binary from Github." \
     && curl -sSL https://github.com/openfaas/faas/releases/download/0.9.14/fwatchdog-armhf > /usr/bin/fwatchdog \
     && chmod +x /usr/bin/fwatchdog \

--- a/template/python3/Dockerfile
+++ b/template/python3/Dockerfile
@@ -4,7 +4,7 @@ FROM python:3-alpine
 ARG ADDITIONAL_PACKAGE
 
 # Alternatively use ADD https:// (which will not be cached by Docker builder)
-RUN apk --no-cache add curl ${ADDITIONAL_PACKAGE} \ 
+RUN apk --no-cache add curl ${ADDITIONAL_PACKAGE} \
     && echo "Pulling watchdog binary from Github." \
     && curl -sSL https://github.com/openfaas/faas/releases/download/0.9.14/fwatchdog > /usr/bin/fwatchdog \
     && chmod +x /usr/bin/fwatchdog \


### PR DESCRIPTION
## Description
It does change the C# example to use string interpolation instead of string.Format and removes some blank lines that are indicated by visual studio code. 

## Which issue(s) this PR fixes 
#127 
#126 

## How Has This Been Tested?
I tested it on my local machine. 

## Types of changes
Minor improvements.

## How Has This Been Tested?

I deployed the faas-stack locally with your deploy_stack.sh.

Then I created a new directory. Copied the from the repo templates (I did not use template pull) into it.
Then I did a 

```
$ faas-cli new --lang chsarp helloworld-new
$ faas-cli build -f helloworld-new.yml
$ faas-cli deploy -f helloworld-new.yml
$ echo "foobar" |faas-cli invoke helloworld-new 
Hi there - your input was: foobar
```

I also did that for the python3 template.

```
$ faas-cli new --lang python3 helloworld-python
$ faas-cli build -f helloworld-python.yml 
$ faas-cli deploy -f helloworld-python.yml 
$ echo "foobar" | faas-cli invoke helloworld-python
foobar
```

I have not tested the arm ones but the only functional change is done to the csharp temlates. The other changes are just cosmetic changes. 