### PR TITLE
Add dockerfile-arm32v6 template

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ This project is part of the OpenFaaS project licensed under the MIT License.
 |:-----|:---------|:--------|:-----------|:---------|:----
 | csharp | C# | N/A | Alpine Linux 3.8 | Classic | [C# template](https://github.com/openfaas/templates/tree/master/template/csharp)
 | dockerfile | Dockerfile | N/A | Alpine Linux 3.8 | Classic | [Dockerfile template](https://github.com/openfaas/templates/tree/master/template/dockerfile)
+| dockerfile-arm32v6 | Dockerfile | N/A | Alpine Linux 3.8 | Classic | [Dockerfile template](https://github.com/openfaas/templates/tree/master/template/dockerfile-arm32v6)
 | go-armhf | Go | 1.10.4 | Alpine Linux 3.8 | Classic | [Go armhf template](https://github.com/openfaas/templates/tree/master/template/go-armhf)
 | go | Go | 1.10.4 | Alpine Linux 3.8 | Classic | [Go template](https://github.com/openfaas/templates/tree/master/template/go)
 |java8 | Java | 8 | OpenJDK Alpine Linux | of-watchdog | [Java template](https://github.com/openfaas/templates/tree/master/template/java8)

--- a/template/dockerfile-arm32v6/function/Dockerfile
+++ b/template/dockerfile-arm32v6/function/Dockerfile
@@ -1,0 +1,29 @@
+FROM arm32v6/alpine:3.8
+
+RUN mkdir -p /home/app
+
+RUN apk --no-cache add curl \
+    && echo "Pulling watchdog binary from Github." \
+    && curl -sSL https://github.com/openfaas/faas/releases/download/0.9.14/fwatchdog-armhf > /usr/bin/fwatchdog \
+    && chmod +x /usr/bin/fwatchdog \
+    && cp /usr/bin/fwatchdog /home/app \
+    && apk del curl --no-cache
+
+# Add non root user
+RUN addgroup -S app && adduser app -S -G app
+
+RUN chown app /home/app
+
+WORKDIR /home/app
+
+USER app
+
+# Populate example here - i.e. "cat", "sha512sum" or "node index.js"
+ENV fprocess="cat"
+# Set to true to see request in function logs
+ENV write_debug="false"
+
+EXPOSE 8080
+
+HEALTHCHECK --interval=3s CMD [ -e /tmp/.lock ] || exit 1
+CMD [ "fwatchdog" ]

--- a/template/dockerfile-arm32v6/template.yml
+++ b/template/dockerfile-arm32v6/template.yml
@@ -1,0 +1,1 @@
+language: dockerfile-arm32v6


### PR DESCRIPTION
Signed-off-by: Pierre CORBEL <pierrot.corbel@gmail.com>

Made a dockerfile arm32v6 template based on the existing dockerfile template

## Description
This allows dockerfile functions to be deployed on arm32v6 cpu

## Motivation and Context
OpenFaaS don't offer as of now the possibility to run dockerfile functions from an official template on a ARM cluster (like Raspberry pi).
- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

## Which issue(s) this PR fixes 
Fixes #132 

## How Has This Been Tested?
The image has been tested directly on a Raspberry Pi.
A simple "Hello World" has been realised

Docker version used was:
```
Client:
 Version:           18.09.0
 API version:       1.39
 Go version:        go1.10.4
 Git commit:        4d60db4
 Built:             Wed Nov  7 00:57:21 2018
 OS/Arch:           linux/arm
 Experimental:      false

Server: Docker Engine - Community
 Engine:
  Version:          18.09.0
  API version:      1.39 (minimum version 1.12)
  Go version:       go1.10.4
  Git commit:       4d60db4
  Built:            Wed Nov  7 00:17:57 2018
  OS/Arch:          linux/arm
  Experimental:     false
```

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
