### PR TITLE
Enable CGO as an option for Go

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,3 @@ build
 .project
 .gradle
 .idea
-template

--- a/template/go/Dockerfile
+++ b/template/go/Dockerfile
@@ -1,6 +1,10 @@
 FROM golang:1.10.4-alpine3.8 as builder
 
-RUN apk --no-cache add curl \
+# Allows you to add additional packages via build-arg
+ARG ADDITIONAL_PACKAGE
+ARG CGO_ENABLED=0
+
+RUN apk --no-cache add curl ${ADDITIONAL_PACKAGE} \
     && echo "Pulling watchdog binary from Github." \
     && curl -sSL https://github.com/openfaas/faas/releases/download/0.9.14/fwatchdog > /usr/bin/fwatchdog \
     && chmod +x /usr/bin/fwatchdog \
@@ -12,7 +16,7 @@ COPY . .
 # Run a gofmt and exclude all vendored code.
 RUN test -z "$(gofmt -l $(find . -type f -name '*.go' -not -path "./vendor/*" -not -path "./function/vendor/*"))" || { echo "Run \"gofmt -s -w\" on your Golang code"; exit 1; }
 
-RUN CGO_ENABLED=0 GOOS=linux \
+RUN CGO_ENABLED=${CGO_ENABLED} GOOS=linux \
     go build --ldflags "-s -w" -a -installsuffix cgo -o handler . && \
     go test $(go list ./... | grep -v /vendor/) -cover
 

--- a/template/go/template.yml
+++ b/template/go/template.yml
@@ -1,5 +1,21 @@
 language: go
 fprocess: ./handler
+build_options:
+  - name: dev
+    packages: 
+      - make
+      - automake
+      - gcc
+      - g++
+      - subversion
+      - python3-dev
+      - musl-dev
+      - libffi-dev
+      - git
+  - name: mysql
+    packages: 
+      - mysql-client
+      - mysql-dev
 welcome_message: |
   You have created a new function which uses Golang 1.10.4
   To include third-party dependencies, use a vendoring tool like dep:

--- a/template/python3/template.yml
+++ b/template/python3/template.yml
@@ -1,6 +1,6 @@
 language: python3
 fprocess: python3 index.py
-build_options: 
+build_options:
   - name: dev
     packages: 
       - make


### PR DESCRIPTION
Signed-off-by: Alex Ellis <alexellis2@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

A user reported a desire to build OpenFaaS functions with CGO
this can now be achieved by passing a build arg of CGO_ENABLED=1
and with build_options dev.

## Motivation and Context

User reported wanting to build SQLite

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested with the "simple" sample from https://github.com/mattn/go-sqlite3

```go
package function

import (
	"database/sql"
	"fmt"
	"log"
	"os"

	_ "github.com/mattn/go-sqlite3"
)

// Handle a serverless request
func Handle(req []byte) string {
	integrationTest()
	return fmt.Sprintf("Hello, Go. You said: %s", string(req))
}

func integrationTest() {
	os.Remove("./foo.db")

	db, err := sql.Open("sqlite3", "./foo.db")
	if err != nil {
		log.Fatal(err)
	}
	defer db.Close()

	sqlStmt := `
	create table foo (id integer not null primary key, name text);
	delete from foo;
	`
	_, err = db.Exec(sqlStmt)
	if err != nil {
		log.Printf("%q: %s\n", err, sqlStmt)
		return
	}

	tx, err := db.Begin()
	if err != nil {
		log.Fatal(err)
	}
	stmt, err := tx.Prepare("insert into foo(id, name) values(?, ?)")
	if err != nil {
		log.Fatal(err)
	}
	defer stmt.Close()
	for i := 0; i < 100; i++ {
		_, err = stmt.Exec(i, fmt.Sprintf("こんにちわ世界%03d", i))
		if err != nil {
			log.Fatal(err)
		}
	}
	tx.Commit()

	rows, err := db.Query("select id, name from foo")
	if err != nil {
		log.Fatal(err)
	}
	defer rows.Close()
	for rows.Next() {
		var id int
		var name string
		err = rows.Scan(&id, &name)
		if err != nil {
			log.Fatal(err)
		}
		fmt.Println(id, name)
	}
	err = rows.Err()
	if err != nil {
		log.Fatal(err)
	}

	stmt, err = db.Prepare("select name from foo where id = ?")
	if err != nil {
		log.Fatal(err)
	}
	defer stmt.Close()
	var name string
	err = stmt.QueryRow("3").Scan(&name)
	if err != nil {
		log.Fatal(err)
	}
	fmt.Println(name)

	_, err = db.Exec("delete from foo")
	if err != nil {
		log.Fatal(err)
	}

	_, err = db.Exec("insert into foo(id, name) values(1, 'foo'), (2, 'bar'), (3, 'baz')")
	if err != nil {
		log.Fatal(err)
	}

	rows, err = db.Query("select id, name from foo")
	if err != nil {
		log.Fatal(err)
	}
	defer rows.Close()
	for rows.Next() {
		var id int
		var name string
		err = rows.Scan(&id, &name)
		if err != nil {
			log.Fatal(err)
		}
		fmt.Println(id, name)
	}
	err = rows.Err()
	if err != nil {
		log.Fatal(err)
	}
}
```

Gave expected output:

```
0 こんにちわ世界000
1 こんにちわ世界001
2 こんにちわ世界002
3 こんにちわ世界003
4 こんにちわ世界004
5 こんにちわ世界005
6 こんにちわ世界006
7 こんにちわ世界007
8 こんにちわ世界008
9 こんにちわ世界009
10 こんにちわ世界010
11 こんにちわ世界011
12 こんにちわ世界012
13 こんにちわ世界013
14 こんにちわ世界014
15 こんにちわ世界015
16 こんにちわ世界016
17 こんにちわ世界017
18 こんにちわ世界018
19 こんにちわ世界019
20 こんにちわ世界020
21 こんにちわ世界021
22 こんにちわ世界022
23 こんにちわ世界023
24 こんにちわ世界024
25 こんにちわ世界025
26 こんにちわ世界026
27 こんにちわ世界027
28 こんにちわ世界028
29 こんにちわ世界029
30 こんにちわ世界030
31 こんにちわ世界031
32 こんにちわ世界032
33 こんにちわ世界033
34 こんにちわ世界034
35 こんにちわ世界035
36 こんにちわ世界036
37 こんにちわ世界037
38 こんにちわ世界038
39 こんにちわ世界039
40 こんにちわ世界040
41 こんにちわ世界041
42 こんにちわ世界042
43 こんにちわ世界043
44 こんにちわ世界044
45 こんにちわ世界045
46 こんにちわ世界046
47 こんにちわ世界047
48 こんにちわ世界048
49 こんにちわ世界049
50 こんにちわ世界050
51 こんにちわ世界051
52 こんにちわ世界052
53 こんにちわ世界053
54 こんにちわ世界054
55 こんにちわ世界055
56 こんにちわ世界056
57 こんにちわ世界057
58 こんにちわ世界058
59 こんにちわ世界059
60 こんにちわ世界060
61 こんにちわ世界061
62 こんにちわ世界062
63 こんにちわ世界063
64 こんにちわ世界064
65 こんにちわ世界065
66 こんにちわ世界066
67 こんにちわ世界067
68 こんにちわ世界068
69 こんにちわ世界069
70 こんにちわ世界070
71 こんにちわ世界071
72 こんにちわ世界072
73 こんにちわ世界073
74 こんにちわ世界074
75 こんにちわ世界075
76 こんにちわ世界076
77 こんにちわ世界077
78 こんにちわ世界078
79 こんにちわ世界079
80 こんにちわ世界080
81 こんにちわ世界081
82 こんにちわ世界082
83 こんにちわ世界083
84 こんにちわ世界084
85 こんにちわ世界085
86 こんにちわ世界086
87 こんにちわ世界087
88 こんにちわ世界088
89 こんにちわ世界089
90 こんにちわ世界090
91 こんにちわ世界091
92 こんにちわ世界092
93 こんにちわ世界093
94 こんにちわ世界094
95 こんにちわ世界095
96 こんにちわ世界096
97 こんにちわ世界097
98 こんにちわ世界098
99 こんにちわ世界099
こんにちわ世界003
1 foo
2 bar
3 baz
Hello, Go. You said: 
```

stack.yml:

```
provider:
  name: faas
  gateway: http://127.0.0.1:8080
functions:
  sqllite:
    lang: go
    handler: ./sqllite
    image: sqllite:0.1
    build_options:
      - dev
```

Build with `faas-cli build -f sqlite.yml --build-arg CGO_ENABLED=1`

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
