### PR TITLE
Update php7 Dockerfile to use watchdog image

### DIFF
--- a/template/php7/Dockerfile
+++ b/template/php7/Dockerfile
@@ -1,3 +1,5 @@
+FROM openfaas/classic-watchdog:0.13.4 as watchdog
+
 # start with the official Composer image and name it
 FROM composer:1.7 AS composer
 
@@ -11,11 +13,10 @@ COPY --from=composer /usr/bin/composer /usr/bin/composer
 ARG COMPOSER_AUTH='{}'
 ENV COMPOSER_AUTH=${COMPOSER_AUTH}
 
-# Add watchdog and packages
-RUN apk add --no-cache git && \
-    echo "Pulling watchdog binary from Github." && \
-    curl -sSL https://github.com/openfaas/faas/releases/download/0.13.0/fwatchdog > /usr/bin/fwatchdog && \
-    chmod +x /usr/bin/fwatchdog
+COPY --from=watchdog /fwatchdog /usr/bin/fwatchdog
+RUN chmod +x /usr/bin/fwatchdog
+
+RUN apk add --no-cache git
 
 # create non-root user
 RUN addgroup -S app && adduser -S -g app app && \


### PR DESCRIPTION
Signed-off-by: Richard Gee <richard@technologee.co.uk>

## Description
Remove the call out to github in favour of using the new Watchdog image.

Since the watchdog image is multi-arch, this should also have the effect of enabling php7 on arm.  Will test this when close to a raspberry pi.

## Motivation and Context
Updates php7 to follow the new pattern.  
Potentially enables php7 on arm.

- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

## Which issue(s) this PR fixes 
Fixes #147
Closes #148 

## How Has This Been Tested?
Used the Dockerfile locally
Created a new function
Ran `faas up`
Ran faas invoke on the new function

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
