### PR TITLE
Update watchdog image to multi-arch 0.13.4

### DIFF
--- a/template/csharp-armhf/Dockerfile
+++ b/template/csharp-armhf/Dockerfile
@@ -1,4 +1,4 @@
-FROM openfaas/classic-watchdog:0.13.1-armhf as watchdog
+FROM openfaas/classic-watchdog:0.13.4 as watchdog
 
 FROM mcr.microsoft.com/dotnet/core/sdk:2.2.203-stretch-arm32v7 as builder
 

--- a/template/csharp/Dockerfile
+++ b/template/csharp/Dockerfile
@@ -1,4 +1,4 @@
-FROM openfaas/classic-watchdog:0.13.1-x86_64 as watchdog
+FROM openfaas/classic-watchdog:0.13.4 as watchdog
 
 FROM microsoft/dotnet:2.1-sdk as builder
 

--- a/template/dockerfile-armhf/function/Dockerfile
+++ b/template/dockerfile-armhf/function/Dockerfile
@@ -1,4 +1,4 @@
-FROM openfaas/classic-watchdog:0.13.1-armhf as watchdog
+FROM openfaas/classic-watchdog:0.13.4 as watchdog
 
 FROM alpine:3.9
 

--- a/template/dockerfile/function/Dockerfile
+++ b/template/dockerfile/function/Dockerfile
@@ -1,4 +1,4 @@
-FROM openfaas/classic-watchdog:0.13.1-x86_64 as watchdog
+FROM openfaas/classic-watchdog:0.13.4 as watchdog
 
 FROM alpine:3.9
 

--- a/template/go-armhf/Dockerfile
+++ b/template/go-armhf/Dockerfile
@@ -1,4 +1,5 @@
-FROM openfaas/classic-watchdog:0.13.1-armhf as watchdog
+FROM openfaas/classic-watchdog:0.13.4 as watchdog
+
 FROM golang:1.10.8-alpine3.9 as builder
 
 # Allows you to add additional packages via build-arg

--- a/template/go/Dockerfile
+++ b/template/go/Dockerfile
@@ -1,4 +1,5 @@
-FROM openfaas/classic-watchdog:0.13.1-x86_64 as watchdog
+FROM openfaas/classic-watchdog:0.13.4 as watchdog
+
 FROM golang:1.10.8-alpine3.9 as builder
 
 # Allows you to add additional packages via build-arg

--- a/template/python/Dockerfile
+++ b/template/python/Dockerfile
@@ -1,4 +1,4 @@
-FROM openfaas/classic-watchdog:0.13.1-x86_64 as watchdog
+FROM openfaas/classic-watchdog:0.13.4 as watchdog
 
 FROM python:2.7-alpine
 

--- a/template/python3/Dockerfile
+++ b/template/python3/Dockerfile
@@ -1,4 +1,4 @@
-FROM openfaas/classic-watchdog:0.13.1-x86_64 as watchdog
+FROM openfaas/classic-watchdog:0.13.4 as watchdog
 
 FROM python:3-alpine
 


### PR DESCRIPTION
Signed-off-by: Richard Gee <richard@technologee.co.uk>

## Description
Updates the templates that were previous moved to the hardware architecture specific Watchdog images so that they all use the multi-arch equivalent.

## Motivation and Context
Reduced maintenance. More generic pattern.
- [ ] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

## Which issue(s) this PR fixes 
<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged): -->
Fixes #

## How Has This Been Tested?
Local builds
Deployed
Invoked

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Maintenance

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
