### PR TITLE
Added GCC to Dockerfile

### DIFF
--- a/template/python3/Dockerfile
+++ b/template/python3/Dockerfile
@@ -9,6 +9,8 @@ COPY --from=watchdog /fwatchdog /usr/bin/fwatchdog
 RUN chmod +x /usr/bin/fwatchdog
 RUN apk --no-cache add ca-certificates ${ADDITIONAL_PACKAGE}
 
+# add GCC (required for Pandas, Numpy, cython modules, etc)
+RUN apk add gcc musl-dev
 
 # Add non root user
 RUN addgroup -S app && adduser app -S -G app


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Added GCC to Dockerfile to allow for Cython-based libraries (Pandas, Numpy, etc)

## Motivation and Context
When `requirements.txt` lists Cython-based libraries (Pandas, Numpy, etc) the command `faas-cli build -f ./function.yml` fails as these require GCC to build.

