### PR TITLE
bump ruby version in template dockerfile

### DIFF
--- a/template/ruby/Dockerfile
+++ b/template/ruby/Dockerfile
@@ -1,6 +1,6 @@
 FROM openfaas/classic-watchdog:0.18.1 as watchdog
 
-FROM ruby:2.5.1-alpine3.7
+FROM ruby:2.7-alpine3.11
 
 COPY --from=watchdog /fwatchdog /usr/bin/fwatchdog
 RUN chmod +x /usr/bin/fwatchdog


### PR DESCRIPTION
bumping ruby & alpine version in dockerfile

## Description
ruby 2.7 was released recently
alpine 3.7 reached its EOL.

## Motivation and Context

## Which issue(s) this PR fixes 

## How Has This Been Tested?
manually build (before and after the change).
`docker run -p 8080:8080 ruby-template:0.1` 
and then
`curl localhost:8080`
which returned
`Hello world from the Ruby template` (as expected)
docker log:
```
2020/01/05 13:33:25 Forking fprocess.
2020/01/05 13:33:25 Wrote 35 Bytes - Duration: 0.072239 seconds
```
## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Version change (see: Impact to existing users)

## Impact to existing users

newer version with backward compatibility.
## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [ ] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
