### PR TITLE
Upgrade versions and used Handler interface

### DIFF
--- a/template/java11-vert-x/entrypoint/build.gradle
+++ b/template/java11-vert-x/entrypoint/build.gradle
@@ -20,7 +20,7 @@ mainClassName = 'App'
 
 dependencies {
     // Vert.x project
-    compile 'io.vertx:vertx-web:3.5.4'
+    compile 'io.vertx:vertx-web:3.8.5'
 
     // Use JUnit test framework
     testCompile 'junit:junit:4.12'

--- a/template/java11-vert-x/entrypoint/src/main/java/com/openfaas/entrypoint/App.java
+++ b/template/java11-vert-x/entrypoint/src/main/java/com/openfaas/entrypoint/App.java
@@ -7,6 +7,9 @@ import io.vertx.core.Vertx;
 import io.vertx.ext.web.Router;
 import io.vertx.ext.web.handler.StaticHandler;
 import io.vertx.ext.web.handler.BodyHandler;
+
+import com.openfaas.function.Handler;
+
 import java.util.Optional;
 
 public class App {
@@ -18,13 +21,15 @@ public class App {
 
     if (Boolean.parseBoolean(Optional.ofNullable(System.getenv("FRONTAPP")).orElse("false"))) {
       // serve static assets, see /resources/webroot directory
-      router.route("/*").handler(StaticHandler.create());
+      router.route().handler(StaticHandler.create());
     } else {
-      BodyHandler handler = new com.openfaas.function.Handler();
-      router.route().handler(handler);
+      // enable body parsing (i.e.: POST, multipart, etc...)
+      router.route().handler(BodyHandler.create());
+      // allow usage of any verb for the function
+      router.route().handler(new Handler());
     }
 
-    server.requestHandler(router::accept).listen(httpPort, result -> {
+    server.requestHandler(router).listen(httpPort, result -> {
       if(result.succeeded()) {
         System.out.println("Listening on port " + httpPort);
       } else {

--- a/template/java11-vert-x/function/build.gradle
+++ b/template/java11-vert-x/function/build.gradle
@@ -13,7 +13,7 @@ plugins {
 
 dependencies {
     // Vert.x project
-    compile 'io.vertx:vertx-web:3.5.4'
+    compile 'io.vertx:vertx-web:3.8.5'
 
     // Use JUnit test framework
     testImplementation 'junit:junit:4.12'    

--- a/template/java11-vert-x/function/src/main/java/com/openfaas/function/Handler.java
+++ b/template/java11-vert-x/function/src/main/java/com/openfaas/function/Handler.java
@@ -1,11 +1,9 @@
 package com.openfaas.function;
 
-import io.vertx.core.http.HttpServerResponse;
 import io.vertx.ext.web.RoutingContext;
-import io.vertx.ext.web.handler.BodyHandler;
 import io.vertx.core.json.JsonObject;
 
-public class Handler implements BodyHandler {
+public class Handler implements io.vertx.core.Handler<RoutingContext> {
 
   @Override
   public void handle(RoutingContext routingContext) {
@@ -16,25 +14,5 @@ public class Handler implements BodyHandler {
           .put("status", "ok")
           .encodePrettily()
       );
-  }
-
-  @Override
-  public BodyHandler setBodyLimit(long bodyLimit) {
-    return null;
-  }
-
-  @Override
-  public BodyHandler setUploadsDirectory(String uploadsDirectory) {
-    return null;
-  }
-
-  @Override
-  public BodyHandler setMergeFormAttributes(boolean mergeFormAttributes) {
-    return null;
-  }
-
-  @Override
-  public BodyHandler setDeleteUploadedFilesOnEnd(boolean deleteUploadedFilesOnEnd) {
-    return null;
   }
 }


### PR DESCRIPTION
Signed-off-by: Paulo Lopes <pmlopes@gmail.com>

The template was using an old version of vert.x and the handler should not implement the BodyHandler interface as it does not mean that you will get the HTTP body parsed. This needs to be passed on the bootstrap project and implement the vert.x Handler functional interface.

As a benefit this makes the function code smaller.

Still the original template or this PR do not expose the router to the function as a setup step. This would be interesting to chain middleware. As an example we could process CORS, or security before the function is executed.

Also post processing is not possible, for example a catch all error handler.