### PR TITLE
Add env vars to use raw body and set max json size

### DIFF
--- a/template/node12/index.js
+++ b/template/node12/index.js
@@ -8,10 +8,15 @@ const app = express()
 const handler = require('./function/handler');
 const bodyParser = require('body-parser')
 
-// app.use(bodyParser.urlencoded({ extended: false }));
-app.use(bodyParser.json());
-app.use(bodyParser.raw());
-app.use(bodyParser.text({ type : "text/*" }));
+if (process.env.RAW_BODY === 'true') {
+    app.use(bodyParser.raw({ type: '*/*' }))
+} else {
+    var jsonLimit = process.env.MAX_JSON_SIZE || '100kb' //body-parser default
+    app.use(bodyParser.json({ limit: jsonLimit}));
+    app.use(bodyParser.raw()); // "Content-Type: application/octet-stream"
+    app.use(bodyParser.text({ type : "text/*" }));
+}
+
 app.disable('x-powered-by');
 
 class FunctionEvent {


### PR DESCRIPTION
## Description
This change adds the use of 2 environment variables: `RAW_BODY` and `MAX_JSON_SIZE`, allowing users to receive the
request body as a buffer (the 'raw' body) as well as the ability to set the maximum
JSON body size.
The raw body is required when processing Stripe webhooks
The max JSON body size is defaulted to a low limit from body-parser which has caused
issues with users in the past.

Signed-off-by: Burton Rheutan <rheutan7@gmail.com>

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [X] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

There was some discussion in the issue linked below. I've decided to implement the change in this was so that it was a more overall change rather than adding it to a specific verb (`POST`) to avoid surprising results when a user sets the `RAW_BODY` to true, it won't be limited only to post requests. 

This also means that `PUT`, `DELETE`, and `GET` requests will also use the raw parser, but I think that would be understood when a user creates a function and explicitly sets the `RAW_BODY` variable to `true` expecting that the raw request body will be used.

## Which issue(s) this PR fixes 
<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged): -->
Fixes #191

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Created sample function to print request body for verifying the type received by the function code.

Using Postman, called the function with `application/json` request.
- No changes - `{ some: 'thing' }`
- env var `RAW_BODY: true` - `<Buffer 7b 0a 09 22 73 6f 6d 65 22 3a 20 22 74 68 69 6e 67 22 0a 7d>`

For the `MAX_JSON_SIZE` testing: 
I've used an example request from [HugeJsonViewer example](https://github.com/WelliSolutions/HugeJsonViewer/blob/master/test/manual/startwitharray.json) that is 1.5mb

Using Postman, called the function with a large request body: 
```sh
node-raw.1.nil4m16x2t2q@pop-os    | 2020/02/01 20:45:49 stderr: PayloadTooLargeError: request entity too large
node-raw.1.nil4m16x2t2q@pop-os    | 2020/02/01 20:45:49 stderr:     at IncomingMessage.onData (/home/app/node_modules/raw-body/index.js:246:12)
node-raw.1.nil4m16x2t2q@pop-os    | 2020/02/01 20:45:49 stderr:     at IncomingMessage.emit (events.js:210:5)
node-raw.1.nil4m16x2t2q@pop-os    | 2020/02/01 20:45:49 stderr:     at addChunk (_stream_readable.js:308:12)
node-raw.1.nil4m16x2t2q@pop-os    | 2020/02/01 20:45:49 stderr:     at readableAddChunk (_stream_readable.js:289:11)
node-raw.1.nil4m16x2t2q@pop-os    | 2020/02/01 20:45:49 stderr:     at IncomingMessage.Readable.push (_stream_readable.js:223:10)
node-raw.1.nil4m16x2t2q@pop-os    | 2020/02/01 20:45:49 stderr:     at HTTPParser.parserOnBody (_http_common.js:128:22)
node-raw.1.nil4m16x2t2q@pop-os    | 2020/02/01 20:45:49 POST / - 413 Payload Too Large - ContentLength: 597
```

Adding the following to the `fn1.yml`:
```yaml
    environment:
      MAX_JSON_SIZE: '5mb'
```

The result was successful: 
```sh
node-raw.1.dzsb7o50ahso@pop-os    | 2020/02/01 20:49:45 stdout:   ... 237 more items
node-raw.1.dzsb7o50ahso@pop-os    | 2020/02/01 20:49:45 stdout: ]
node-raw.1.dzsb7o50ahso@pop-os    | 2020/02/01 20:49:45 POST / - 200 OK - ContentLength: 5424
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Version change (see: Impact to existing users)

## Impact to existing users
None as the changes are wrapped in an environment variable. Verified the function works as expected without the env vars defined or used.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [X] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
