### PR TITLE
Run unit tests for node12 if present

### DIFF
--- a/template/node12/Dockerfile
+++ b/template/node12/Dockerfile
@@ -1,5 +1,4 @@
 FROM openfaas/of-watchdog:0.7.2 as watchdog
-
 FROM node:12.13.0-alpine as ship
 
 COPY --from=watchdog /fwatchdog /usr/bin/fwatchdog
@@ -27,12 +26,18 @@ COPY index.js ./
 
 # COPY function node packages and install, adding this as a separate
 # entry allows caching of npm install
+
 WORKDIR /home/app/function
+
 COPY function/*.json ./
+
 RUN npm i || :
 
 # COPY function files and folders
 COPY function/ ./
+
+# Run any tests that may be available
+RUN npm test
 
 # Set correct permissions to use non root user
 WORKDIR /home/app/

--- a/template/node12/function/package.json
+++ b/template/node12/function/package.json
@@ -1,12 +1,12 @@
 {
-  "name": "function",
+  "name": "openfaas-function",
   "version": "1.0.0",
-  "description": "",
+  "description": "OpenFaaS Function",
   "main": "handler.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 0"
   },
   "keywords": [],
-  "author": "",
-  "license": "ISC"
+  "author": "OpenFaaS Ltd",
+  "license": "MIT"
 }

--- a/template/node12/package.json
+++ b/template/node12/package.json
@@ -1,14 +1,14 @@
 {
-  "name": "node12",
+  "name": "openfaas-node12",
   "version": "1.0.0",
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no tests specified\" && exit 0"
   },
   "keywords": [],
-  "author": "",
-  "license": "ISC",
+  "author": "OpenFaaS Ltd",
+  "license": "MIT",
   "dependencies": {
     "body-parser": "^1.18.2",
     "express": "^4.16.2"

--- a/template/node12/template.yml
+++ b/template/node12/template.yml
@@ -1,7 +1,12 @@
 language: node12
 fprocess: node index.js
 welcome_message: |
-  You have created a new function which uses Node.js 12.13.0 and the OpenFaaS
-  of-watchdog.
+  You have created a new function which uses Node.js 12 (TLS) and the OpenFaaS
+  of-watchdog which gives greater control over HTTP responses.
+
   npm i --save can be used to add third-party packages like request or cheerio
   npm documentation: https://docs.npmjs.com/
+
+  Unit tests are run at build time via "npm run", edit package.json to specify 
+  how you want to execute them.
+


### PR DESCRIPTION
Run unit tests for node12 if present

This change allows npm test to be run in during the Docker build
of code using the node12 template. Unfortunately the package.json
that the template generated will fail for any users who take this
newer version, unless they edit the "test" section of their
package.json file.

This is because it is hard-coded to "exit 1", the newer change
is set to "exit 0" and to only show a warning about tests
missing. It will not affect any functions that are created
after this time.

Tested with 3 scenarios:

* Tests given which passed, with mocha and chai
* Tests given which failed with mocha and chai
* No tests given at all

Signed-off-by: Alex Ellis (OpenFaaS Ltd) <alexellis2@gmail.com>

This was change requested by a user on Slack, but is consistent with the Java and Go templates. All templates should try to run tests if they are available. 