### PR TITLE
Java8 template: added openfaas dependencies

### DIFF
--- a/template/java8/function/build.gradle
+++ b/template/java8/function/build.gradle
@@ -21,7 +21,8 @@ dependencies {
     // Use JUnit test framework
     testImplementation 'junit:junit:4.12'
 
-    compile project(':model')
+    compile 'com.openfaas:model:0.1.1'
+    compile 'com.openfaas:entrypoint:0.1.0'
 }
 
 // In this section you declare where to find the dependencies of your project


### PR DESCRIPTION
Openfaas dependencies needed to make the Java8 template compile


## Description
The command `faas-cli new --lang java8 java-function` generated a java project which was not compiling due to missing dependencies in the gradle file.

## Motivation and Context
Change is required to assure that users (still) using Java8 can generate a proper function template. Although Java8 is end-of-life, it is still used.

## Which issue(s) this PR fixes 
-

## How Has This Been Tested?
- Verified whether the Gradle build succeeds
- Build and deployed the function generated by the template on a local kubernetes cluster with OpenFaas installed. Function properly returned "Hello, world!"
- `verify.sh` succeeded

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Impact to existing users
Users using java8 can finally compile the generated template again

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
