### PR TITLE
Support binary payloads and responses, and non-UTF8 string payloads for Python functions

### DIFF
--- a/template/python3/index.py
+++ b/template/python3/index.py
@@ -28,5 +28,12 @@ if __name__ == "__main__":
     # otherwise keep bytes
 
     ret = handler.handle(st)
-    if ret != None:
-        print(ret)
+
+    # encode response to JSON if necessary
+    if ret is not None:
+        if isinstance(ret, bytes):
+            sys.stdout.buffer.write(ret)
+        elif isinstance(ret, str):
+            sys.stdout.write(ret)
+        else:
+            json.dump(ret, sys.stdout)


### PR DESCRIPTION
closes #205 and replaces #207 

## Description
In addition to handling binary input as in #207, this PR also handles binary output, properly encodes returned Python dicts as compliant JSON (double quotes instead of single quotes) and can handle all text encodings. All this processing is controlled by the headers according to web standards.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

## Which issue(s) this PR fixes 
Fixes #205 

## How Has This Been Tested?
Deployed on an internal project that takes audio files/JSON as payload and response, running on Ubuntu and macOS.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Version change (see: Impact to existing users)

## Impact to existing users
UTF8 text payloads (the only ones supported so far) are passed as before.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
