### PR TITLE
Fixing warnings in PHP template

### DIFF
--- a/template/php7/function/composer.json
+++ b/template/php7/function/composer.json
@@ -1,7 +1,8 @@
 {
-    "name": "function-php7.2",
+    "name": "openfaas/function-php7.2",
     "description": "Template for function in PHP 7.2",
     "type": "project",
+    "license": "proprietary",
     "config": {
         "classmap-authoritative": true
     },

--- a/template/php7/function/src/Handler.php
+++ b/template/php7/function/src/Handler.php
@@ -12,7 +12,8 @@ class Handler
      * @param $data
      * @return
      */
-    public function handle($data) {
+    public function handle($data)
+    {
         return $data;
     }
 }


### PR DESCRIPTION
## Description

This fixes a few warning you get when using the PHP template:

- naming convention (missing `/`) which will become an error with composer v2: `Deprecation warning: Your package name function-php7.2 is invalid, it should have a vendor name, a forward slash, and a package name. The vendor and package name can be words separated by -, . or _. The complete name should match "^[a-z0-9]([_.-]?[a-z0-9]+)*/[a-z0-9](([_.]?|-{0,2})[a-z0-9]+)*$". Make sure you fix this as Composer 2.0 will error.`
- missing license

## Motivation and Context

To avoid fixing every time.


## How Has This Been Tested?

 - `cd` into folder
 - `composer validate`

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Version change (see: Impact to existing users)

## Impact to existing users

As a template it shouldn't affect any existing users.

<!-- If none, state why and how you can be sure of that. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
