### PR TITLE
Adding templates for newer composer+PHP versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ This repository contains the Classic OpenFaaS templates, but many more are avail
 | java11 | Java | 11 | Debian GNU/Linux | of-watchdog | [Java LTS template](https://github.com/openfaas/templates/tree/master/template/java11)
 | ruby | Ruby | 2.7 | Alpine Linux 3.11 | classic| [Ruby template](https://github.com/openfaas/templates/tree/master/template/ruby)
 | php7 | PHP | 7.2 | Alpine Linux | classic | [PHP 7 template](https://github.com/openfaas/templates/tree/master/template/php7)
+| php7.4 | PHP | 7.4 | Alpine Linux | classic | [PHP 7.4 template](https://github.com/openfaas/templates/tree/master/template/php7.4)
+| php8.0 | PHP | 8.0 | Alpine Linux | classic | [PHP 8.0 template](https://github.com/openfaas/templates/tree/master/template/php8.0)
 | csharp | C# | N/A | Debian GNU/Linux 9 | classic | [C# template](https://github.com/openfaas/templates/tree/master/template/csharp)
 
 For more information on the templates check out the [docs](https://docs.openfaas.com/cli/templates/).

--- a/template/php7.4/Dockerfile
+++ b/template/php7.4/Dockerfile
@@ -4,10 +4,10 @@ ARG BUILDPLATFORM
 FROM --platform=${TARGETPLATFORM:-linux/amd64} ghcr.io/openfaas/classic-watchdog:0.1.4 as watchdog
 
 # start with the official Composer image and name it
-FROM --platform=${TARGETPLATFORM:-linux/amd64} composer:1.7 AS composer
+FROM --platform=${TARGETPLATFORM:-linux/amd64} composer:2 AS composer
 
 # continue with the official PHP image
-FROM --platform=${TARGETPLATFORM:-linux/amd64} php:7.2-alpine
+FROM --platform=${TARGETPLATFORM:-linux/amd64} php:7.4-alpine
 
 # copy the Composer PHAR from the Composer image into the PHP image
 COPY --from=composer /usr/bin/composer /usr/bin/composer

--- a/template/php7.4/function/composer.json
+++ b/template/php7.4/function/composer.json
@@ -1,0 +1,17 @@
+{
+    "name": "openfaas/function-php7.4",
+    "description": "Template for function in PHP 7.4",
+    "type": "project",
+    "license": "proprietary",
+    "config": {
+        "classmap-authoritative": true
+    },
+    "autoload": {
+        "psr-4": {
+            "App\\": "src/"
+        }
+    },
+    "require": {
+        "php": "^7.4"
+    }
+}

--- a/template/php7.4/function/php-extension.sh
+++ b/template/php7.4/function/php-extension.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+echo "Installing PHP extensions"
+
+# Add your extensions in here, an example is below
+# docker-php-ext-install mysqli
+#
+# See the template documentation for instructions on installing extensions;
+# - https://github.com/openfaas/templates/tree/master/template/php7
+#
+# You can also install any apk packages here

--- a/template/php7.4/function/src/Handler.php
+++ b/template/php7.4/function/src/Handler.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App;
+
+/**
+ * Class Handler
+ * @package App
+ */
+class Handler
+{
+    /**
+     * @param $data
+     * @return
+     */
+    public function handle($data)
+    {
+        return $data;
+    }
+}

--- a/template/php7.4/index.php
+++ b/template/php7.4/index.php
@@ -1,0 +1,10 @@
+<?php
+
+// Requires Function composer's autoload
+if (file_exists('function/vendor/autoload.php')) {
+    require('function/vendor/autoload.php');
+}
+
+$stdin = file_get_contents("php://stdin");
+$response = (new App\Handler())->handle($stdin);
+echo $response;

--- a/template/php7.4/php-extension.sh-example
+++ b/template/php7.4/php-extension.sh-example
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+echo "Installing PHP extensions"
+docker-php-ext-install pdo_mysql
+
+# Install Phalcon
+PHALCON_VERSION=3.4.0
+PHALCON_EXT_PATH=php7/64bits
+
+set -xe && \
+        # Compile Phalcon
+        curl -LO https://github.com/phalcon/cphalcon/archive/v${PHALCON_VERSION}.tar.gz && \
+        tar xzf ${PWD}/v${PHALCON_VERSION}.tar.gz && \
+        docker-php-ext-install -j $(getconf _NPROCESSORS_ONLN) ${PWD}/cphalcon-${PHALCON_VERSION}/build/${PHALCON_EXT_PATH} && \
+        # Remove all temp files
+        rm -r \
+            ${PWD}/v${PHALCON_VERSION}.tar.gz \
+            ${PWD}/cphalcon-${PHALCON_VERSION}

--- a/template/php7.4/readme.md
+++ b/template/php7.4/readme.md
@@ -1,0 +1,41 @@
+# PHP7 Template
+
+Templates are built using the latest minor version of the major release.
+
+| Modules (by default) |
+| ------------- |
+| Core, date, libxml, openssl, pcre, sqlite3, zlib, ctype, curl, dom, fileinfo, filter, ftp, hash, iconv, json, mbstring, SPL, PDO, pdo_sqlite, session, posix, readline, Reflection, standard, SimpleXML, Phar, tokenizer, xml, xmlreader, xmlwriter, mysqlnd, sodium |
+
+## Usage:
+
+```shell
+faas-cli new my-function --lang php7
+```
+
+You will find in the newly created directory `my-function`:
+
+- `src/Handler.php` : entrypoint
+- `php-extension.sh` : is for installing PHP extensions if needed
+- `composer.json` : is for dependency management
+
+## Extra Extensions
+
+If you need to install [Phalcon](https://github.com/phalcon) for example, check out the
+following sample which you could use in your functions `src/php-extension.sh` file;
+
+- [php-extension.sh-example](php-extension.sh-example)
+
+You can also refer to the PHP Docker image [documentation](https://github.com/docker-library/docs/blob/master/php/README.md#how-to-install-more-php-extensions) for additional instructions on the installation and configuration of extensions
+
+## Private Composer Auth
+
+In some cases, you may need to use private composer repositories - using the `faas-cli` you can pass in
+a build argument during build, for example;
+
+```
+faas-cli build -f ./functions.yml \
+  --build-arg COMPOSER_AUTH='{"bitbucket-oauth": {"bitbucket.org": {"consumer-key": "xxxxxxxx","consumer-secret": "xxxxxxx"}}}'
+```
+See more information [here](https://getcomposer.org/doc/05-repositories.md#git-alternatives).
+
+That way you can pass in tokens for Composer, if necessary, GitHub tokens to get around rate-limit issues.

--- a/template/php7.4/readme.md
+++ b/template/php7.4/readme.md
@@ -1,4 +1,4 @@
-# PHP7 Template
+# PHP 7.4 Template
 
 Templates are built using the latest minor version of the major release.
 
@@ -9,7 +9,7 @@ Templates are built using the latest minor version of the major release.
 ## Usage:
 
 ```shell
-faas-cli new my-function --lang php7
+faas-cli new my-function --lang php7.4
 ```
 
 You will find in the newly created directory `my-function`:

--- a/template/php7.4/template.yml
+++ b/template/php7.4/template.yml
@@ -1,0 +1,7 @@
+language: php7.4
+fprocess: php index.php
+welcome_message: |
+  You have created a new function which uses PHP 7.4.
+  Dependencies and extensions can be added using the composer.json
+  and php-extension.sh files.
+  See https://github.com/openfaas/templates/blob/master/template/php7.

--- a/template/php7.4/template.yml
+++ b/template/php7.4/template.yml
@@ -4,4 +4,4 @@ welcome_message: |
   You have created a new function which uses PHP 7.4.
   Dependencies and extensions can be added using the composer.json
   and php-extension.sh files.
-  See https://github.com/openfaas/templates/blob/master/template/php7.
+  See https://github.com/openfaas/templates/blob/master/template/php7.4

--- a/template/php7/readme.md
+++ b/template/php7/readme.md
@@ -1,4 +1,4 @@
-# PHP7 Template
+# PHP 7.2 Template
 
 Templates are built using the latest minor version of the major release.
 

--- a/template/php8.0/Dockerfile
+++ b/template/php8.0/Dockerfile
@@ -4,10 +4,10 @@ ARG BUILDPLATFORM
 FROM --platform=${TARGETPLATFORM:-linux/amd64} ghcr.io/openfaas/classic-watchdog:0.1.4 as watchdog
 
 # start with the official Composer image and name it
-FROM --platform=${TARGETPLATFORM:-linux/amd64} composer:1.7 AS composer
+FROM --platform=${TARGETPLATFORM:-linux/amd64} composer:2 AS composer
 
 # continue with the official PHP image
-FROM --platform=${TARGETPLATFORM:-linux/amd64} php:7.2-alpine
+FROM --platform=${TARGETPLATFORM:-linux/amd64} php:8.0-alpine
 
 # copy the Composer PHAR from the Composer image into the PHP image
 COPY --from=composer /usr/bin/composer /usr/bin/composer

--- a/template/php8.0/function/composer.json
+++ b/template/php8.0/function/composer.json
@@ -1,0 +1,17 @@
+{
+    "name": "openfaas/function-php8.0",
+    "description": "Template for function in PHP 8.0",
+    "type": "project",
+    "license": "proprietary",
+    "config": {
+        "classmap-authoritative": true
+    },
+    "autoload": {
+        "psr-4": {
+            "App\\": "src/"
+        }
+    },
+    "require": {
+        "php": "^8.0"
+    }
+}

--- a/template/php8.0/function/php-extension.sh
+++ b/template/php8.0/function/php-extension.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+echo "Installing PHP extensions"
+
+# Add your extensions in here, an example is below
+# docker-php-ext-install mysqli
+#
+# See the template documentation for instructions on installing extensions;
+# - https://github.com/openfaas/templates/tree/master/template/php7
+#
+# You can also install any apk packages here

--- a/template/php8.0/function/src/Handler.php
+++ b/template/php8.0/function/src/Handler.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App;
+
+/**
+ * Class Handler
+ * @package App
+ */
+class Handler
+{
+    /**
+     * @param $data
+     * @return
+     */
+    public function handle($data)
+    {
+        return $data;
+    }
+}

--- a/template/php8.0/index.php
+++ b/template/php8.0/index.php
@@ -1,0 +1,10 @@
+<?php
+
+// Requires Function composer's autoload
+if (file_exists('function/vendor/autoload.php')) {
+    require('function/vendor/autoload.php');
+}
+
+$stdin = file_get_contents("php://stdin");
+$response = (new App\Handler())->handle($stdin);
+echo $response;

--- a/template/php8.0/php-extension.sh-example
+++ b/template/php8.0/php-extension.sh-example
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+echo "Installing PHP extensions"
+docker-php-ext-install pdo_mysql
+
+# Install Phalcon
+PHALCON_VERSION=3.4.0
+PHALCON_EXT_PATH=php7/64bits
+
+set -xe && \
+        # Compile Phalcon
+        curl -LO https://github.com/phalcon/cphalcon/archive/v${PHALCON_VERSION}.tar.gz && \
+        tar xzf ${PWD}/v${PHALCON_VERSION}.tar.gz && \
+        docker-php-ext-install -j $(getconf _NPROCESSORS_ONLN) ${PWD}/cphalcon-${PHALCON_VERSION}/build/${PHALCON_EXT_PATH} && \
+        # Remove all temp files
+        rm -r \
+            ${PWD}/v${PHALCON_VERSION}.tar.gz \
+            ${PWD}/cphalcon-${PHALCON_VERSION}

--- a/template/php8.0/readme.md
+++ b/template/php8.0/readme.md
@@ -1,0 +1,41 @@
+# PHP7 Template
+
+Templates are built using the latest minor version of the major release.
+
+| Modules (by default) |
+| ------------- |
+| Core, date, libxml, openssl, pcre, sqlite3, zlib, ctype, curl, dom, fileinfo, filter, ftp, hash, iconv, json, mbstring, SPL, PDO, pdo_sqlite, session, posix, readline, Reflection, standard, SimpleXML, Phar, tokenizer, xml, xmlreader, xmlwriter, mysqlnd, sodium |
+
+## Usage:
+
+```shell
+faas-cli new my-function --lang php7
+```
+
+You will find in the newly created directory `my-function`:
+
+- `src/Handler.php` : entrypoint
+- `php-extension.sh` : is for installing PHP extensions if needed
+- `composer.json` : is for dependency management
+
+## Extra Extensions
+
+If you need to install [Phalcon](https://github.com/phalcon) for example, check out the
+following sample which you could use in your functions `src/php-extension.sh` file;
+
+- [php-extension.sh-example](php-extension.sh-example)
+
+You can also refer to the PHP Docker image [documentation](https://github.com/docker-library/docs/blob/master/php/README.md#how-to-install-more-php-extensions) for additional instructions on the installation and configuration of extensions
+
+## Private Composer Auth
+
+In some cases, you may need to use private composer repositories - using the `faas-cli` you can pass in
+a build argument during build, for example;
+
+```
+faas-cli build -f ./functions.yml \
+  --build-arg COMPOSER_AUTH='{"bitbucket-oauth": {"bitbucket.org": {"consumer-key": "xxxxxxxx","consumer-secret": "xxxxxxx"}}}'
+```
+See more information [here](https://getcomposer.org/doc/05-repositories.md#git-alternatives).
+
+That way you can pass in tokens for Composer, if necessary, GitHub tokens to get around rate-limit issues.

--- a/template/php8.0/readme.md
+++ b/template/php8.0/readme.md
@@ -1,4 +1,4 @@
-# PHP7 Template
+# PHP 8.0 Template
 
 Templates are built using the latest minor version of the major release.
 
@@ -9,7 +9,7 @@ Templates are built using the latest minor version of the major release.
 ## Usage:
 
 ```shell
-faas-cli new my-function --lang php7
+faas-cli new my-function --lang php8.0
 ```
 
 You will find in the newly created directory `my-function`:

--- a/template/php8.0/template.yml
+++ b/template/php8.0/template.yml
@@ -4,4 +4,4 @@ welcome_message: |
   You have created a new function which uses PHP 8.0.
   Dependencies and extensions can be added using the composer.json
   and php-extension.sh files.
-  See https://github.com/openfaas/templates/blob/master/template/php7.
+  See https://github.com/openfaas/templates/blob/master/template/php8.0

--- a/template/php8.0/template.yml
+++ b/template/php8.0/template.yml
@@ -1,0 +1,7 @@
+language: php8.0
+fprocess: php index.php
+welcome_message: |
+  You have created a new function which uses PHP 8.0.
+  Dependencies and extensions can be added using the composer.json
+  and php-extension.sh files.
+  See https://github.com/openfaas/templates/blob/master/template/php7.


### PR DESCRIPTION
Hey @alexellis

This PR adds PHP templates to add support for PHP 7.4 and 8.0. With this the composer version has been upgraded as well. The templates are mostly copied from the existing template. 

I have left out 7.3 as it's almost out of support (tmr), but I could add it (if desired).

## How Has This Been Tested?

The templates work. I've build and tested them. 

Currently the `verify.sh` run fails silently. I assume it's caused by the dot in the path or template name. Not sure how this should be handled.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Version change (see: Impact to existing users)

## Impact to existing users

Templates should affect existing users afaik.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
