### PR TITLE
Minor documentation fix - links to node12 and node14 in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@ This repository contains the Classic OpenFaaS templates, but many more are avail
 |:-----|:---------|:--------|:-----------|:---------|:----
 | dockerfile | Dockerfile | N/A | Alpine Linux | classic | [Dockerfile template](https://github.com/openfaas/templates/tree/master/template/dockerfile)
 | go | Go | 1.15 | Alpine Linux | classic | [Go template](https://github.com/openfaas/templates/tree/master/template/go)
-| node12 | NodeJS | 12 | Alpine Linux | of-watchdog | [NodeJS template](https://github.com/openfaas/templates/tree/master/template/node14)
-| node14 | NodeJS | 14 | Alpine Linux | of-watchdog | [NodeJS template](https://github.com/openfaas/templates/tree/master/template/node12)
+| node12 | NodeJS | 12 | Alpine Linux | of-watchdog | [NodeJS template](https://github.com/openfaas/templates/tree/master/template/node12)
+| node14 | NodeJS | 14 | Alpine Linux | of-watchdog | [NodeJS template](https://github.com/openfaas/templates/tree/master/template/node14)
 | node | NodeJS | 12 | Alpine Linux | classic | [NodeJS template](https://github.com/openfaas/templates/tree/master/template/node)
 | python3 | Python | 3 | Alpine Linux | classic | [Python 3 template](https://github.com/openfaas/templates/tree/master/template/python3)
 | python3-debian | Python | 3 | Debian Linux | classic | [Python 3 Debian template](https://github.com/openfaas/templates/tree/master/template/python3-debian)


### PR DESCRIPTION
## Description
Fixed hyperlinks to `node12` and `node14` templates source code so that they are located in the matching template row.

## Motivation and Context
Minor documentation issue that can be confusing.
- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

## Which issue(s) this PR fixes 
Fixes #250.

## How Has This Been Tested?
* Browsed README.md in the adequate branch on github.com ;
* Clicked the links ;
* Verified that the correct directory was displayed.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Version change (see: Impact to existing users)

## Impact to existing users

<!-- If none, state why and how you can be sure of that. -->

## Checklist:
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
