### PR TITLE
Fixes node14 Dockerfile to reference the correct Node.js Docker image version

### DIFF
--- a/template/node14/Dockerfile
+++ b/template/node14/Dockerfile
@@ -1,5 +1,5 @@
 FROM --platform=${TARGETPLATFORM:-linux/amd64} ghcr.io/openfaas/of-watchdog:0.8.4 as watchdog
-FROM --platform=${TARGETPLATFORM:-linux/amd64} node:12-alpine as ship
+FROM --platform=${TARGETPLATFORM:-linux/amd64} node:14-alpine as ship
 
 ARG TARGETPLATFORM
 ARG BUILDPLATFORM


### PR DESCRIPTION
Signed-off-by: Guillaume Grussenmeyer <ggrussenmeyer@protonmail.com>

## Description
Update `node` Docker image version to `14-alpine` in `node14/Dockerfile` (was `12-alpine`).

## Motivation and Context
- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

## Which issue(s) this PR fixes 
Fixes #253 

## How Has This Been Tested?
By verifying the output of `docker run node14-ci node --version`.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Version change (see: Impact to existing users)

## Impact to existing users
Users that thought they were running Node.js v14 when using the `node14` template were actually running v12.
After this PR they'll be actually running v14.
I'm unable to evaluate the effective impact; YMMV.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
