### PR TITLE
Fixes issue #255: Can't access HTTP request body in java11-vert-x template.

### DIFF
--- a/template/java11-vert-x/entrypoint/src/main/java/com/openfaas/entrypoint/App.java
+++ b/template/java11-vert-x/entrypoint/src/main/java/com/openfaas/entrypoint/App.java
@@ -6,6 +6,7 @@ import io.vertx.core.http.HttpServer;
 import io.vertx.core.Vertx;
 import io.vertx.ext.web.Router;
 import io.vertx.ext.web.RoutingContext;
+import io.vertx.ext.web.handler.BodyHandler;
 import io.vertx.ext.web.handler.StaticHandler;
 import java.util.Optional;
 
@@ -16,6 +17,7 @@ public class App {
     HttpServer server = vertx.createHttpServer();
     Router router = Router.router(vertx);
 
+    router.route().handler(BodyHandler.create());
     if (Boolean.parseBoolean(Optional.ofNullable(System.getenv("FRONTAPP")).orElse("false"))) {
       // serve static assets, see /resources/webroot directory
       router.route("/*").handler(StaticHandler.create());


### PR DESCRIPTION
Signed-off-by: Patrik Fortier <patrik.fortier@insa-lyon.fr>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Added a `io.vertx.ext.web.handler.BodyHandler` instance to the handlers to populate routingContext with the HTTP request body.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

## Which issue(s) this PR fixes 
<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged): -->
Fixes #255 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I deployed a function reading the http request body using the modified 


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Version change (see: Impact to existing users)

## Impact to existing users
<!-- If none, state why and how you can be sure of that. -->
Adds one handler to the router. According to vertx documentation, the overhead is negligible.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [ ] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
