### PR TITLE
Add custom status when failing a node12/14 request

### DIFF
--- a/template/node12/index.js
+++ b/template/node12/index.js
@@ -54,18 +54,18 @@ class FunctionEvent {
 
 class FunctionContext {
     constructor(cb) {
-        this.value = 200;
+        this.statusCode = 200;
         this.cb = cb;
         this.headerValues = {};
         this.cbCalled = 0;
     }
 
-    status(value) {
-        if(!value) {
-            return this.value;
+    status(statusCode) {
+        if(!statusCode) {
+            return this.statusCode;
         }
 
-        this.value = value;
+        this.statusCode = statusCode;
         return this;
     }
 
@@ -86,6 +86,10 @@ class FunctionContext {
 
     fail(value) {
         let message;
+        if(this.status() == "200") {
+            this.status(500)
+        }
+
         this.cbCalled++;
         this.cb(value, message);
     }
@@ -96,7 +100,7 @@ const middleware = async (req, res) => {
         if (err) {
             console.error(err);
 
-            return res.status(500)
+            return res.status(fnContext.status())
                 .send(err.toString ? err.toString() : err);
         }
 

--- a/template/node14/index.js
+++ b/template/node14/index.js
@@ -54,18 +54,18 @@ class FunctionEvent {
 
 class FunctionContext {
     constructor(cb) {
-        this.value = 200;
+        this.statusCode = 200;
         this.cb = cb;
         this.headerValues = {};
         this.cbCalled = 0;
     }
 
-    status(value) {
-        if(!value) {
-            return this.value;
+    status(statusCode) {
+        if(!statusCode) {
+            return this.statusCode;
         }
 
-        this.value = value;
+        this.statusCode = statusCode;
         return this;
     }
 
@@ -86,6 +86,10 @@ class FunctionContext {
 
     fail(value) {
         let message;
+        if(this.status() == "200") {
+            this.status(500)
+        }
+
         this.cbCalled++;
         this.cb(value, message);
     }
@@ -96,7 +100,7 @@ const middleware = async (req, res) => {
         if (err) {
             console.error(err);
 
-            return res.status(500)
+            return res.status(fnContext.status())
                 .send(err.toString ? err.toString() : err);
         }
 


### PR DESCRIPTION
Signed-off-by: Alex Ellis (OpenFaaS Ltd) <alexellis2@gmail.com>

## Description
<!--- Describe your changes in detail -->

Add custom status when failing a node12/14 request

Tested with a 401 status before failing the message and saw
the code as expected.
Also tested with just calling fail, and saw the 500 code.

Closes #258 and Fixes: #257


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Version change (see: Impact to existing users)

## Impact to existing users

N/a - no harm.
