### PR TITLE
Update Go version to 1.16 for alpine image

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This repository contains the Classic OpenFaaS templates, but many more are avail
 | Name | Language | Version | Linux base | Watchdog | Link
 |:-----|:---------|:--------|:-----------|:---------|:----
 | dockerfile | Dockerfile | N/A | Alpine Linux | classic | [Dockerfile template](https://github.com/openfaas/templates/tree/master/template/dockerfile)
-| go | Go | 1.15 | Alpine Linux | classic | [Go template](https://github.com/openfaas/templates/tree/master/template/go)
+| go | Go | 1.16 | Alpine Linux | classic | [Go template](https://github.com/openfaas/templates/tree/master/template/go)
 | node12 | NodeJS | 12 | Alpine Linux | of-watchdog | [NodeJS template](https://github.com/openfaas/templates/tree/master/template/node12)
 | node14 | NodeJS | 14 | Alpine Linux | of-watchdog | [NodeJS template](https://github.com/openfaas/templates/tree/master/template/node14)
 | node | NodeJS | 12 | Alpine Linux | classic | [NodeJS template](https://github.com/openfaas/templates/tree/master/template/node)

--- a/template/go/Dockerfile
+++ b/template/go/Dockerfile
@@ -1,5 +1,5 @@
 FROM --platform=${TARGETPLATFORM:-linux/amd64} ghcr.io/openfaas/classic-watchdog:0.1.5 as watchdog
-FROM --platform=${BUILDPLATFORM:-linux/amd64} golang:1.15-alpine3.13 as builder
+FROM --platform=${BUILDPLATFORM:-linux/amd64} golang:1.16-alpine3.13 as builder
 
 ARG TARGETPLATFORM
 ARG BUILDPLATFORM
@@ -39,7 +39,7 @@ WORKDIR /go/src/handler
 RUN GOOS=${TARGETOS} GOARCH=${TARGETARCH} CGO_ENABLED=${CGO_ENABLED} \
     go build --ldflags "-s -w" -a -installsuffix cgo -o handler .
 
-FROM --platform=${TARGETPLATFORM:-linux/amd64} alpine:3.12
+FROM --platform=${TARGETPLATFORM:-linux/amd64} alpine:3.13
 RUN apk --no-cache add ca-certificates \
     && addgroup -S app && adduser -S -g app app \
     && mkdir -p /home/app \

--- a/template/go/go.mod
+++ b/template/go/go.mod
@@ -1,5 +1,5 @@
 module handler
 
-go 1.15
+go 1.16
 
 replace handler/function => ./function

--- a/template/go/template.yml
+++ b/template/go/template.yml
@@ -17,7 +17,7 @@ build_options:
       - mysql-client
       - mysql-dev
 welcome_message: |
-  You have created a new function which uses Golang 1.13 and the Classic
+  You have created a new function which uses Golang 1.16 and the Classic
   OpenFaaS template.
 
   To include third-party dependencies, use Go modules and use


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Had to bump the versions over 1.15 due to arm64 bug from golang alpine image

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [X] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md)) https://github.com/openfaas/templates/issues/268

## Which issue(s) this PR fixes 
<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged): -->
Fixes # The issue fixes arm64 faas-cli up which doesn't work on golang alpine image 1.15. It works with 1.16 and 1.17 tho.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
Get raspberry pi 4/400, install faas-cli, change templates dockerfile to arm64. Do faas-cli up and you will get error about amd64 image tried to fetch git in arm64 system.

<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
This will affect all ARM64 users who want to do deployments with faas-cli.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Version change (see: Impact to existing users)

## Impact to existing users
If you are using arm64 system, you won't be able to do faas-cli up -f stacks.yml, it requires a change in dockerfile and after that is done to linux/arm64 somehow golang alpine image 1.15 still installs amd64 which I think the related issue to docker repository. Official Alpine go images are 1.16 and 1.17 now. 1.15 is no longer supported for arm64.

![1 15](https://user-images.githubusercontent.com/22800416/130324965-d60e068c-0a04-4530-9b85-59b5621db492.png)
![1 15-alpine-go-image-issue](https://user-images.githubusercontent.com/22800416/130324966-fd3004af-5e6b-43ef-98e7-3b2fd67556c2.png)


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [X] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
