### PR TITLE
Update java11-vertx to use a shadow jar

### DIFF
--- a/template/java11-vert-x/Dockerfile
+++ b/template/java11-vert-x/Dockerfile
@@ -1,6 +1,5 @@
 FROM openjdk:11-jdk-slim as builder
 
-ENV GRADLE_VER=6.1.1
 RUN apt-get update -qqy \
   && apt-get install -qqy \
    --no-install-recommends \
@@ -8,6 +7,7 @@ RUN apt-get update -qqy \
    ca-certificates \
    unzip
 
+ENV GRADLE_VER=7.3.3
 RUN mkdir -p /opt/ && cd /opt/ \
     && echo "Downloading gradle.." \
     && curl -sSfL "https://services.gradle.org/distributions/gradle-${GRADLE_VER}-bin.zip" -o gradle-$GRADLE_VER-bin.zip \
@@ -26,21 +26,15 @@ WORKDIR /home/app
 COPY . /home/app/
 
 RUN gradle build
-RUN find . 
 
 FROM ghcr.io/openfaas/of-watchdog:0.9.3 as watchdog
 FROM openjdk:11-jre-slim as ship
-RUN apt-get update -qqy \
-  && apt-get install -qqy \
-   --no-install-recommends \
-   unzip
 
 COPY --from=watchdog /fwatchdog /usr/bin/fwatchdog
 RUN chmod +x /usr/bin/fwatchdog
 
 WORKDIR /home/app
-COPY --from=builder /home/app/entrypoint/build/distributions/entrypoint-1.0.zip ./entrypoint-1.0.zip
-RUN unzip ./entrypoint-1.0.zip
+COPY --from=builder /home/app/entrypoint/build/libs/app.jar ./app.jar
 
 RUN addgroup --system app \
     && adduser --system --ingroup app app
@@ -52,9 +46,9 @@ USER app
 
 ENV upstream_url="http://127.0.0.1:8082"
 ENV mode="http"
-ENV CLASSPATH="/home/app/entrypoint-1.0/lib/*"
+# ENV CLASSPATH="/home/app/entrypoint-1.0/lib/*"
 
-ENV fprocess="java -XX:+UseContainerSupport -Dvertx.cacheDirBase=/tmp/.vertx-cache com.openfaas.entrypoint.App"
+ENV fprocess="java -XX:+UseContainerSupport -Dvertx.cacheDirBase=/tmp/.vertx-cache -jar app.jar"
 EXPOSE 8080
 
 HEALTHCHECK --interval=5s CMD [ -e /tmp/.lock ] || exit 1

--- a/template/java11-vert-x/entrypoint/build.gradle
+++ b/template/java11-vert-x/entrypoint/build.gradle
@@ -13,26 +13,30 @@ plugins {
     // Apply the application plugin to add support for building an application
     id 'application'
 
+    id 'com.github.johnrengelman.shadow' version '7.1.2'
+
 }
 
 // Define the main class for the application
-mainClassName = 'App'
+mainClassName = 'com.openfaas.entrypoint.App'
 
 dependencies {
     // Vert.x project
-    compile 'io.vertx:vertx-web:3.5.4'
+    implementation 'io.vertx:vertx-web:3.5.4'
 
     // Use JUnit test framework
-    testCompile 'junit:junit:4.12'
+    testImplementation 'junit:junit:4.12'
 
-    compile project(':function')
+    implementation project(':function')
 }
 
-jar {
+shadowJar {
     manifest {
         attributes 'Implementation-Title': 'OpenFaaS Function',
-                   'Implementation-Version': version
+                   'Implementation-Version': version,
+                   'Main-Class': mainClassName
     }
+    archiveFileName.set('app.jar')
 }
 
 // In this section you declare where to find the dependencies of your project
@@ -42,10 +46,12 @@ repositories {
     jcenter()
 }
 
-uploadArchives {
-    repositories {
-       flatDir {
-           dirs 'repos'
-       }
-    }
-}
+// uploadArchives {
+//     repositories {
+//        flatDir {
+//            dirs 'repos'
+//        }
+//     }
+// }
+
+assemble.dependsOn(shadowJar)

--- a/template/java11-vert-x/function/build.gradle
+++ b/template/java11-vert-x/function/build.gradle
@@ -13,7 +13,7 @@ plugins {
 
 dependencies {
     // Vert.x project
-    compile 'io.vertx:vertx-web:3.5.4'
+    implementation 'io.vertx:vertx-web:3.5.4'
 
     // Use JUnit test framework
     testImplementation 'junit:junit:4.12'    


### PR DESCRIPTION
Signed-off-by: Alex Ellis (OpenFaaS Ltd) <alexellis2@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Update java11-vertx to use a shadow jar

## Motivation and Context

@koogordo suggested that using a shadow jar reduces the total size of functions using this template. Early testing showed up to 100MB in saving, and removed the zip/unzip stage from the build, making it quicker.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested by running a docker build inside the template folder and running the container with docker, the code continued to work as expected.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Version change (see: Impact to existing users)

Optimization, plus an upgrade to Gradle 7.3.3

## Impact to existing users

<!-- If none, state why and how you can be sure of that. -->

The change in gradle version may mean changing "compile" to "implementation" within your gradle scripts.
