### PR TITLE
Allow static files to be published into final image for Go template

### DIFF
--- a/template/go/Dockerfile
+++ b/template/go/Dockerfile
@@ -1,5 +1,5 @@
 FROM --platform=${TARGETPLATFORM:-linux/amd64} ghcr.io/openfaas/classic-watchdog:0.2.0 as watchdog
-FROM --platform=${BUILDPLATFORM:-linux/amd64} golang:1.18-alpine3.15 as builder
+FROM --platform=${BUILDPLATFORM:-linux/amd64} golang:1.18-alpine3.15 as build
 
 ARG TARGETPLATFORM
 ARG BUILDPLATFORM
@@ -28,6 +28,7 @@ COPY . .
 RUN test -z "$(gofmt -l $(find . -type f -name '*.go' -not -path "./vendor/*" -not -path "./function/vendor/*"))" || { echo "Run \"gofmt -s -w\" on your Golang code"; exit 1; }
 
 WORKDIR /go/src/handler/function
+RUN mkdir -p /go/src/handler/function/static
 
 RUN GOOS=${TARGETOS} GOARCH=${TARGETARCH} CGO_ENABLED=${CGO_ENABLED} go test ./... -cover
 
@@ -36,19 +37,16 @@ WORKDIR /go/src/handler
 RUN GOOS=${TARGETOS} GOARCH=${TARGETARCH} CGO_ENABLED=${CGO_ENABLED} \
     go build --ldflags "-s -w" -a -installsuffix cgo -o handler .
 
-FROM --platform=${TARGETPLATFORM:-linux/amd64} alpine:3.12
+FROM --platform=${TARGETPLATFORM:-linux/amd64} alpine:3.15 as ship
+
 RUN apk --no-cache add ca-certificates \
-    && addgroup -S app && adduser -S -g app app \
-    && mkdir -p /home/app \
-    && chown app /home/app
+    && addgroup -S app && adduser -S -g app app
 
 WORKDIR /home/app
 
-COPY --from=builder /usr/bin/fwatchdog         .
-COPY --from=builder /go/src/handler/function/  .
-COPY --from=builder /go/src/handler/handler    .
-
-RUN chown -R app /home/app
+COPY --from=build --chown=app /usr/bin/fwatchdog                  .
+COPY --from=build --chown=app /go/src/handler/handler             .
+COPY --from=build --chown=app /go/src/handler/function/static   static
 
 USER app
 


### PR DESCRIPTION
Signed-off-by: Alex Ellis (OpenFaaS Ltd) <alexellis2@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Allow static files to be published into final image for Go template
## Motivation and Context

Allows code to be published into final image, without leaking additional source code into container.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

```go
package function

import (
	"fmt"
	"io/ioutil"
	"os"

	"log"
)

// Handle a serverless request
func Handle(req []byte) string {

	data, err := ioutil.ReadFile("./static/hostname")

	if err != nil {
		log.Println(err)
		os.Exit(-1)
	}

	return fmt.Sprintf("File contents: %s", string(data))
}

```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Version change (see: Impact to existing users)

## How are existing users impacted? What migration steps/scripts do we need?

This is a *breaking change* for existing users who rely on folder names such as `templates` or `dataset.json` within their published image.

Now, put these files into the `static` folder and read them from `./static/templates/index.html` and so forth.

## Checklist:

A note will be published in the openfaas docs repo for this new change.
