### PR TITLE
Add support for git tokens, to be used for python dependencies from private git repos, in the main python template.

### DIFF
--- a/template/python3/Dockerfile
+++ b/template/python3/Dockerfile
@@ -1,56 +1,88 @@
-FROM --platform=${TARGETPLATFORM:-linux/amd64} ghcr.io/openfaas/classic-watchdog:0.2.0 as watchdog
-FROM --platform=${TARGETPLATFORM:-linux/amd64} python:3-alpine
+# Builder stage that allows you to use git modules from private repos
+FROM --platform=${TARGETPLATFORM:-linux/amd64} python:3-alpine as builder
 
-ARG TARGETPLATFORM
-ARG BUILDPLATFORM
-
-# Allows you to add additional packages via build-arg
+# Basic user, python and certificate setup
 ARG ADDITIONAL_PACKAGE
-
-COPY --from=watchdog /fwatchdog /usr/bin/fwatchdog
-RUN chmod +x /usr/bin/fwatchdog
 RUN apk --no-cache add ca-certificates ${ADDITIONAL_PACKAGE}
-
-
-# Add non root user
 RUN addgroup -S app && adduser app -S -G app
-
 WORKDIR /home/app/
-
-COPY index.py           .
-COPY requirements.txt   .
-
 RUN chown -R app /home/app && \
-  mkdir -p /home/app/python && chown -R app /home/app
+    mkdir -p /home/app/python && chown -R app /home/app
 USER app
 ENV PATH=$PATH:/home/app/.local/bin:/home/app/python/bin/
 ENV PYTHONPATH=$PYTHONPATH:/home/app/python
 
+# Token to be provided as argument
+ARG GIT_TOKEN=no_token_set
+
+# Install git and make the git token available as environment variable
+USER root
+RUN apk --no-cache add git
+ENV GIT_TOKEN=${GIT_TOKEN}
+
+# Install template requirements
+USER app
+WORKDIR /home/app/
+COPY requirements.txt   .
 RUN pip install -r requirements.txt --target=/home/app/python
 
+# Install function specific requirements
+RUN mkdir -p function
+WORKDIR /home/app/function/
+COPY function/requirements.txt	.
+RUN pip install -r requirements.txt --target=/home/app/python
+
+FROM --platform=${TARGETPLATFORM:-linux/amd64} ghcr.io/openfaas/classic-watchdog:0.2.0 as watchdog
+
+# Actual image
+FROM --platform=${TARGETPLATFORM:-linux/amd64} python:3-alpine
+
+# Basic user, python and certificate setup
+ARG ADDITIONAL_PACKAGE
+RUN apk --no-cache add ca-certificates ${ADDITIONAL_PACKAGE}
+RUN addgroup -S app && adduser app -S -G app
+WORKDIR /home/app/
+RUN chown -R app /home/app && \
+    mkdir -p /home/app/python && chown -R app /home/app
+USER app
+ENV PATH=$PATH:/home/app/.local/bin:/home/app/python/bin/
+ENV PYTHONPATH=$PYTHONPATH:/home/app/python
+
+# Copy over watchdog
+USER root
+COPY --from=watchdog /fwatchdog /usr/bin/fwatchdog
+RUN chmod +x /usr/bin/fwatchdog
+
+# Copy over template files
+USER app
+WORKDIR /home/app/
+COPY index.py           .
+COPY requirements.txt   .
+
+# Mark the function dir as a module
 RUN mkdir -p function
 RUN touch ./function/__init__.py
 
+# Copy over the function specific requirements file
 WORKDIR /home/app/function/
 COPY function/requirements.txt	.
 
-RUN pip install -r requirements.txt --target=/home/app/python
-
+# Copy over resolved dependencies from builder stage
 WORKDIR /home/app/
+COPY --from=builder /home/app/.cache /home/app/.cache
+COPY --from=builder /home/app/python /home/app/python
 
+# Copy over the specific function code
 USER root
-
 COPY function           function
 
 # Allow any user-id for OpenShift users.
 RUN chown -R app:app ./ && \
-  chmod -R 777 /home/app/python
+    chmod -R 777 /home/app/python
 
+# Prepare and run the watchdog
 USER app
-
 ENV fprocess="python3 index.py"
 EXPOSE 8080
-
 HEALTHCHECK --interval=3s CMD [ -e /tmp/.lock ] || exit 1
-
 CMD ["fwatchdog"]

--- a/template/python3/Dockerfile
+++ b/template/python3/Dockerfile
@@ -18,19 +18,18 @@ ARG GIT_TOKEN=no_token_set
 # Install git and make the git token available as environment variable
 USER root
 RUN apk --no-cache add git
-ENV GIT_TOKEN=${GIT_TOKEN}
 
 # Install template requirements
 USER app
 WORKDIR /home/app/
 COPY requirements.txt   .
-RUN pip install -r requirements.txt --target=/home/app/python
+RUN GIT_TOKEN=${GIT_TOKEN} pip install -r requirements.txt --target=/home/app/python
 
 # Install function specific requirements
 RUN mkdir -p function
 WORKDIR /home/app/function/
 COPY function/requirements.txt	.
-RUN pip install -r requirements.txt --target=/home/app/python
+RUN GIT_TOKEN=${GIT_TOKEN} pip install -r requirements.txt --target=/home/app/python
 
 FROM --platform=${TARGETPLATFORM:-linux/amd64} ghcr.io/openfaas/classic-watchdog:0.2.0 as watchdog
 


### PR DESCRIPTION
## Description
This change adds the ability to provide a GIT_TOKEN as a build argument. This git token is then set as an environment variable.
Also the pip install code is moved to a builder stage.

## Motivation and Context
The reason to make this GIT_TOKEN environment variable available, is so that it can be used when adding the following kind of dependency to requirements.txt: 
```
git+https://${GITHUB_TOKEN}@github.com/user/project.git@{version}
```
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

## Which issue(s) this PR fixes 
<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged): -->
Fixes openfaas/faas#1723

## How Has This Been Tested?
It has been tested by creating a python module in a private github repo (using [this video](https://youtu.be/DhUpxWjOhME?t=174) as an instruction). Then I created a python project with a requirements.txt file that uses this private git repo as a dependency.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Version change (see: Impact to existing users)

## Impact to existing users
This doesn't have any direct impact on the end users, as the resulting image will contain the same files. The image layers are slightly different though, due to the pip install commands being moved to a builder stage. This has a very small impact on how the layers are cached, but since the the default requirements.txt in the template doesn't have any dependencies, this doesn't matter all that much.

## Checklist:
- [x] My code follows the code style of this project. (I think? Is there such a thing as a Dockerfile code style?)
- [ ] My change requires a change to the documentation. (Though explaining the ability to use the GIT_TOKEN would be nice)
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes. (Not applicable I think?)
- [x] All new and existing tests passed.
