### PR TITLE
Provide a PHP 8 template

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ This repository contains the Classic OpenFaaS templates, but many more are avail
 | java11 | Java | 11 | Debian GNU/Linux | of-watchdog | [Java LTS template](https://github.com/openfaas/templates/tree/master/template/java11)
 | ruby | Ruby | 2.7 | Alpine Linux 3.11 | classic| [Ruby template](https://github.com/openfaas/templates/tree/master/template/ruby)
 | php7 | PHP | 7.4 | Alpine Linux | classic | [PHP 7 template](https://github.com/openfaas/templates/tree/master/template/php7)
+| php8 | PHP | 8.1 | Alpine Linux | classic | [PHP 8 template](https://github.com/openfaas/templates/tree/master/template/php8)
 | csharp | C# | N/A | Debian GNU/Linux 9 | classic | [C# template](https://github.com/openfaas/templates/tree/master/template/csharp)
 
 For more information on the templates check out the [docs](https://docs.openfaas.com/cli/templates/).

--- a/template/php8/Dockerfile
+++ b/template/php8/Dockerfile
@@ -1,0 +1,56 @@
+ARG TARGETPLATFORM
+ARG BUILDPLATFORM
+
+FROM --platform=${TARGETPLATFORM:-linux/amd64} ghcr.io/openfaas/classic-watchdog:0.2.1 as watchdog
+
+# start with the official Composer image and name it
+FROM --platform=${TARGETPLATFORM:-linux/amd64} composer:latest AS composer
+
+# continue with the official PHP image
+FROM --platform=${TARGETPLATFORM:-linux/amd64} php:8.1-alpine
+
+# copy the Composer PHAR from the Composer image into the PHP image
+COPY --from=composer /usr/bin/composer /usr/bin/composer
+
+# Composer requirements
+ARG COMPOSER_AUTH='{}'
+ENV COMPOSER_AUTH=${COMPOSER_AUTH}
+
+COPY --from=watchdog /fwatchdog /usr/bin/fwatchdog
+RUN chmod +x /usr/bin/fwatchdog
+
+RUN apk add --no-cache git
+
+# create non-root user
+RUN addgroup -S app && adduser -S -g app app && \
+    mkdir -p /home/app
+
+# Import function
+WORKDIR /home/app
+COPY index.php ./
+COPY ./function ./function
+WORKDIR /home/app/function
+
+# Install php extensions
+RUN [[ -f php-extension.sh ]] && sh ./php-extension.sh && \
+    chown -R app /home/app
+
+# Entry
+USER app
+
+# Install Composer Dependecies
+RUN [[ -f composer.lock || -f composer.json ]] && composer install --no-dev
+
+USER root
+
+# Cleanup
+RUN apk del git && \
+    rm -rf /usr/src/php && \
+    { find /usr/local/lib -type f -print0 | xargs -0r strip --strip-all -p 2>/dev/null || true; }
+
+USER app
+
+WORKDIR /home/app
+ENV fprocess="php index.php"
+HEALTHCHECK --interval=3s CMD [ -e /tmp/.lock ] || exit 1
+CMD ["fwatchdog"]

--- a/template/php8/function/composer.json
+++ b/template/php8/function/composer.json
@@ -1,0 +1,17 @@
+{
+    "name": "openfaas/function-php8.1",
+    "description": "Template for function in PHP 8.1",
+    "type": "project",
+    "license": "proprietary",
+    "config": {
+        "classmap-authoritative": true
+    },
+    "autoload": {
+        "psr-4": {
+            "App\\": "src/"
+        }
+    },
+    "require": {
+        "php": "^8.1"
+    }
+}

--- a/template/php8/function/php-extension.sh
+++ b/template/php8/function/php-extension.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+echo "Installing PHP extensions"
+
+# Add your extensions in here, an example is below
+# docker-php-ext-install mysqli
+#
+# See the template documentation for instructions on installing extensions;
+# - https://github.com/openfaas/templates/tree/master/template/php8
+#
+# You can also install any apk packages here

--- a/template/php8/function/php-extension.sh
+++ b/template/php8/function/php-extension.sh
@@ -2,8 +2,7 @@
 
 echo "Installing PHP extensions"
 
-# Add your extensions in here, an example is below
-# docker-php-ext-install mysqli
+# Add your extensions here, you can find a valid example in php-extension.example.sh
 #
 # See the template documentation for instructions on installing extensions;
 # - https://github.com/openfaas/templates/tree/master/template/php8

--- a/template/php8/function/src/Handler.php
+++ b/template/php8/function/src/Handler.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App;
+
+/**
+ * Class Handler
+ * @package App
+ */
+class Handler
+{
+    /**
+     * @param string $data
+     * @return string
+     */
+    public function handle(string $data): string
+    {
+        return $data;
+    }
+}

--- a/template/php8/index.php
+++ b/template/php8/index.php
@@ -1,0 +1,10 @@
+<?php
+
+// Requires Function composer's autoload
+if (file_exists('function/vendor/autoload.php')) {
+    require('function/vendor/autoload.php');
+}
+
+$stdin = file_get_contents("php://stdin");
+$response = (new App\Handler())->handle($stdin);
+echo $response;

--- a/template/php8/php-extension.example.sh
+++ b/template/php8/php-extension.example.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+echo "Installing PHP extensions"
+
+# docker-php-ext-install is requiring the wrong dependency to install the zip extension, we can use Alpine's apk to circumvent the issue
+apk add libzip-dev
+docker-php-ext-install zip

--- a/template/php8/php-extension.sh-example
+++ b/template/php8/php-extension.sh-example
@@ -1,4 +1,0 @@
-#!/bin/sh
-
-echo "Installing PHP extensions"
-docker-php-ext-install pdo_mysql

--- a/template/php8/php-extension.sh-example
+++ b/template/php8/php-extension.sh-example
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+echo "Installing PHP extensions"
+docker-php-ext-install pdo_mysql

--- a/template/php8/readme.md
+++ b/template/php8/readme.md
@@ -14,15 +14,15 @@ faas-cli new my-function --lang php8
 
 You will find in the newly created directory `my-function`:
 
-- `src/Handler.php` : entrypoint
-- `php-extension.sh` : is for installing PHP extensions if needed
-- `composer.json` : is for dependency management
+- `src/Handler.php`: entrypoint
+- `php-extension.sh`: is for installing PHP extensions if needed
+- `composer.json`: is for dependency management
 
 ## Extra Extensions
 
-If you need to install PHP extensions, check out the following example, which you could use in your functions `src/php-extension.sh` file;
+If you need to install PHP extensions, check out the following example, which you could use in your `php-extension.sh` file:
 
-- [php-extension.sh-example](php-extension.sh-example)
+- [php-extension.example.sh](php-extension.example.sh)
 
 You can also refer to the PHP Docker image [documentation](https://github.com/docker-library/docs/blob/master/php/README.md#how-to-install-more-php-extensions) for additional instructions on the installation and configuration of extensions.
 

--- a/template/php8/readme.md
+++ b/template/php8/readme.md
@@ -1,0 +1,40 @@
+# PHP8 Template
+
+Templates are built using the latest minor version of the major release.
+
+| Modules (by default) |
+| ------------- |
+| Core, ctype, curl, date, dom, fileinfo, filter, ftp, hash, iconv, json, libxml, mbstring, mysqlnd, openssl, pcre, PDO, pdo_mysql, pdo_sqlite, Phar, posix, readline, Reflection, session, SimpleXML, sodium, SPL, sqlite3, standard, tokenizer, xml, xmlreader, xmlwriter, zlib |
+
+## Usage:
+
+```shell
+faas-cli new my-function --lang php8
+```
+
+You will find in the newly created directory `my-function`:
+
+- `src/Handler.php` : entrypoint
+- `php-extension.sh` : is for installing PHP extensions if needed
+- `composer.json` : is for dependency management
+
+## Extra Extensions
+
+If you need to install PHP extensions, check out the following example, which you could use in your functions `src/php-extension.sh` file;
+
+- [php-extension.sh-example](php-extension.sh-example)
+
+You can also refer to the PHP Docker image [documentation](https://github.com/docker-library/docs/blob/master/php/README.md#how-to-install-more-php-extensions) for additional instructions on the installation and configuration of extensions.
+
+## Private Composer Auth
+
+In some cases, you may need to use private composer repositories - using the `faas-cli` you can pass in
+a build argument during build, for example;
+
+```
+faas-cli build -f ./functions.yml \
+  --build-arg COMPOSER_AUTH='{"bitbucket-oauth": {"bitbucket.org": {"consumer-key": "xxxxxxxx","consumer-secret": "xxxxxxx"}}}'
+```
+See more information [here](https://getcomposer.org/doc/05-repositories.md#git-alternatives).
+
+That way you can pass in tokens for Composer, if necessary, GitHub tokens to get around rate-limit issues.

--- a/template/php8/template.yml
+++ b/template/php8/template.yml
@@ -1,0 +1,7 @@
+language: php8
+fprocess: php index.php
+welcome_message: |
+  You have created a new function which uses PHP 8.1.
+  Dependencies and extensions can be added using the composer.json
+  and php-extension.sh files.
+  See https://github.com/openfaas/templates/blob/master/template/php8.


### PR DESCRIPTION
## Description
I added a new subfolder in the `template` directory, containing a PHP 8 template, including the `:latest` Composer image.
Further I had to remove the Phalcon example on installing extensions, because Phalcon right now has no PHP 8 support. It's being worked on, but I don't know when it will be available, so I removed it. The example is still available in the PHP 7 template.

## Motivation and Context
As described in #293 , PHP 7's end of life is near, so there is a need for a fresh PHP 8 template. The old template was also locked to an old version of Composer, hence I updated the Dockerfile to always use the latest version of Composer (v2). Also updated classic-watchdog version.

- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

## Which issue(s) this PR fixes 
Fixes #293.

## How Has This Been Tested?
I verified that the build including the extensions example works, and did some simple tests by deploying the resulting image to a VPS running `faasd`. Also ran `./verify.sh`, worked.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Version change (see: Impact to existing users)

## Impact to existing users

Existing users will have the chance to create a template using PHP 8, the old PHP 7 template is still available. The `php7` template should be removed as soon as PHP 7 reaches end-of-.life (28 Nov 2022). Until then it might be nice to have a fallback solution.

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
