### PR TITLE
feat: support build arg to pin the python3 version

### DIFF
--- a/template/python3-debian/Dockerfile
+++ b/template/python3-debian/Dockerfile
@@ -1,5 +1,6 @@
+ARG PYTHON_VERSION=3
 FROM --platform=${TARGETPLATFORM:-linux/amd64} ghcr.io/openfaas/classic-watchdog:0.2.1 as watchdog
-FROM --platform=${TARGETPLATFORM:-linux/amd64} python:3
+FROM --platform=${TARGETPLATFORM:-linux/amd64} python:${PYTHON_VERSION}
 
 ARG TARGETPLATFORM
 ARG BUILDPLATFORM

--- a/template/python3/Dockerfile
+++ b/template/python3/Dockerfile
@@ -1,5 +1,6 @@
+ARG PYTHON_VERSION=3
 FROM --platform=${TARGETPLATFORM:-linux/amd64} ghcr.io/openfaas/classic-watchdog:0.2.1 as watchdog
-FROM --platform=${TARGETPLATFORM:-linux/amd64} python:3-alpine
+FROM --platform=${TARGETPLATFORM:-linux/amd64} python:${PYTHON_VERSION}-alpine
 
 ARG TARGETPLATFORM
 ARG BUILDPLATFORM


### PR DESCRIPTION
Add a build arg to the python3 templates so that developers can pin the python version.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [ ] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

Relates to https://github.com/openfaas/python-flask-template/pull/67 and keeps the Python templates consistent.


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Manually tested with the default "echo" function

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Version change (see: Impact to existing users)

## Impact to existing users

<!-- If none, state why and how you can be sure of that. -->
None, the current templates are equivalent and track the default latest python3 tag, the only change is the support to pin it to a specific tag via a build arg.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
