### PR TITLE
Fix name in package.json for node20 template (#313)

### DIFF
--- a/template/node20/package.json
+++ b/template/node20/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "openfaas-node18",
+  "name": "openfaas-node20",
   "version": "1.0.0",
   "description": "",
   "main": "index.js",


### PR DESCRIPTION
## Description
Renamed the template from `openfaas-node18` to `openfaas-node20` in `package.json`.

## Motivation and Context
This change is required to prevent confusion, as the current template name `openfaas-node18` does not correctly represent the Node.js version. Renaming the template to `openfaas-node20` aligns it with the correct Node.js version.

- [x] I have raised an issue to propose this change ([Issue #313](https://github.com/openfaas/faas/issues/313))

## Which issue(s) this PR fixes 
Fixes #313

## How Has This Been Tested?
The change was reviewed by verifying the updated `name` field in `package.json`. No other functionality is affected by this change, so no additional testing was required.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Impact to existing users
None, as this change only affects the template name for clarity.

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide.
- [x] I have signed-off my commits with `git commit -s`.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.